### PR TITLE
Planemo lint error fix

### DIFF
--- a/trimmomatic/run_planemo_tests.sh
+++ b/trimmomatic/run_planemo_tests.sh
@@ -34,6 +34,6 @@ for dep in $TOOL_DEPENDENCIES ; do
     fi
 done
 # Run the planemo tests
-planemo test $@ $(dirname $0)/trimmomatic.xml
+planemo test $@ $(dirname $0)/trimmomatic.xml --test_data test-data
 ##
 #

--- a/trimmomatic/run_planemo_tests.sh
+++ b/trimmomatic/run_planemo_tests.sh
@@ -34,6 +34,6 @@ for dep in $TOOL_DEPENDENCIES ; do
     fi
 done
 # Run the planemo tests
-planemo test $@ $(dirname $0)/trimmomatic.xml --test_data test-data
+planemo test $@ $(dirname $0)/trimmomatic.xml
 ##
 #

--- a/trimmomatic/trimmomatic.xml
+++ b/trimmomatic/trimmomatic.xml
@@ -9,7 +9,7 @@
   <command interpreter="bash"><![CDATA[
   trimmomatic.sh
   -mx8G
-  -jar \$TRIMMOMATIC_DIR/trimmomatic-$TRIMMOMATIC_VER.jar
+  -jar \$TRIMMOMATIC_DIR/trimmomatic-0.32.jar
   #if $paired_end.is_paired_end
     PE -threads \${GALAXY_SLOTS:-6} -phred33
     #set $paired_input_type = $paired_end.paired_input_type_conditional.paired_input_type
@@ -96,6 +96,7 @@
       <param name="palindrome_clip_threshold" type="integer" label="How accurate the match between the two 'adapter ligated' reads must be for PE palindrome read alignment" value="30" />
       <param name="simple_clip_threshold" type="integer" label="How accurate the match between any adapter etc. sequence must be against a read" value="10" />
     </when>
+    <when value="no" /> <!-- empty clause to satisfy planemo lint -->
     </conditional>
     <repeat name="operations" title="Trimmomatic Operation" min="1">
       <conditional name="operation">

--- a/trimmomatic/trimmomatic.xml
+++ b/trimmomatic/trimmomatic.xml
@@ -9,7 +9,7 @@
   <command interpreter="bash"><![CDATA[
   trimmomatic.sh
   -mx8G
-  -jar \$TRIMMOMATIC_DIR/trimmomatic-0.32.jar
+  -jar \$TRIMMOMATIC_DIR/trimmomatic-$TRIMMOMATIC_VER.jar
   #if $paired_end.is_paired_end
     PE -threads \${GALAXY_SLOTS:-6} -phred33
     #set $paired_input_type = $paired_end.paired_input_type_conditional.paired_input_type


### PR DESCRIPTION
A fix to planemo lint which was failing due to a missing <when value="no" />  on the trimmomatic.xml file.
