### PR TITLE
Update rnachipintegrator tool to use version 1.0.1

### DIFF
--- a/tools/rnachipintegrator/README.rst
+++ b/tools/rnachipintegrator/README.rst
@@ -104,6 +104,7 @@ History
 ========== ======================================================================
 Version    Changes
 ---------- ----------------------------------------------------------------------
+1.0.1.0    - Update to use latest ``RnaChipIntegrator`` version 1.0.1.
 1.0.0.0    - Update to use latest ``RnaChipIntegrator`` version 1.0.0.
 0.5.0-0    - Significant update to bring tools in line with
              ``RnaChipIntegrator`` version 0.5.0, including removing the

--- a/tools/rnachipintegrator/install_tool_deps.sh
+++ b/tools/rnachipintegrator/install_tool_deps.sh
@@ -15,13 +15,13 @@ if [ ! -d "$TOP_DIR" ] ; then
     mkdir -p $TOP_DIR
 fi
 cd $TOP_DIR
-# RnaChipIntegrator 1.0.0
-VERSION=1.0.0
+# RnaChipIntegrator 1.0.1
+VERSION=1.0.1
 INSTALL_DIR=$TOP_DIR/rnachipintegrator/$VERSION
 mkdir -p $INSTALL_DIR
 wd=$(mktemp -d)
 pushd $wd
-wget https://pypi.python.org/packages/source/R/RnaChipIntegrator/RnaChipIntegrator-${VERSION}.tar.gz
+wget https://pypi.python.org/packages/b6/dd/8e7187194fe438b9ceeb26e92c4852014d47c612989dae54160822172635/RnaChipIntegrator-${VERSION}.tar.gz
 tar zxf RnaChipIntegrator-${VERSION}.tar.gz
 cd RnaChipIntegrator-$VERSION
 pip install --no-use-wheel --install-option "--prefix=$INSTALL_DIR" .

--- a/tools/rnachipintegrator/rnachipintegrator_macros.xml
+++ b/tools/rnachipintegrator/rnachipintegrator_macros.xml
@@ -1,9 +1,9 @@
 <macros>
-  <token name="@VERSION@">1.0.0</token>
+  <token name="@VERSION@">1.0.1</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="0.8.4">python_xlsxwriter</requirement>
-      <requirement type="package" version="1.0.0">rnachipintegrator</requirement>
+      <requirement type="package" version="1.0.1">rnachipintegrator</requirement>
     </requirements>
   </xml>
   <xml name="version_command">
@@ -61,7 +61,7 @@
   journal = {GitHub repository},
   year = {2016},
   howpublished = {\url{https://github.com/fls-bioinformatics-core/RnaChipIntegrator}},
-  version = {1.0.0}
+  version = {1.0.1}
 }</citation>
     </citations>
   </xml>

--- a/tools/rnachipintegrator/run_planemo_tests.sh
+++ b/tools/rnachipintegrator/run_planemo_tests.sh
@@ -13,7 +13,7 @@
 #                         Galaxy instance)
 #
 # List of dependencies
-TOOL_DEPENDENCIES="rnachipintegrator/1.0.0
+TOOL_DEPENDENCIES="rnachipintegrator/1.0.1
  xlsxwriter/0.8.4"
 # Where to find them
 TOOL_DEPENDENCIES_DIR=$(pwd)/test.tool_dependencies.rnachipintegrator

--- a/tools/rnachipintegrator/tool_dependencies.xml
+++ b/tools/rnachipintegrator/tool_dependencies.xml
@@ -20,7 +20,7 @@
   <package name="rnachipintegrator" version="1.0.1">
     <install version="1.0">
       <actions>
-	<action type="download_by_url">https://pypi.python.org/packages/source/R/RnaChipIntegrator/RnaChipIntegrator-1.0.1.tar.gz</action>
+	<action type="download_by_url">https://pypi.python.org/packages/b6/dd/8e7187194fe438b9ceeb26e92c4852014d47c612989dae54160822172635/RnaChipIntegrator-1.0.1.tar.gz</action>
         <action type="shell_command">
 	  pip install --no-use-wheel --install-option "--prefix=$INSTALL_DIR" .
 	</action>

--- a/tools/rnachipintegrator/tool_dependencies.xml
+++ b/tools/rnachipintegrator/tool_dependencies.xml
@@ -17,10 +17,10 @@
     </install>
     <readme>Installs Python module XlsxWriter 0.8.4</readme>
   </package>
-  <package name="rnachipintegrator" version="1.0.0">
+  <package name="rnachipintegrator" version="1.0.1">
     <install version="1.0">
       <actions>
-	<action type="download_by_url">https://pypi.python.org/packages/source/R/RnaChipIntegrator/RnaChipIntegrator-1.0.0.tar.gz</action>
+	<action type="download_by_url">https://pypi.python.org/packages/source/R/RnaChipIntegrator/RnaChipIntegrator-1.0.1.tar.gz</action>
         <action type="shell_command">
 	  pip install --no-use-wheel --install-option "--prefix=$INSTALL_DIR" .
 	</action>
@@ -30,6 +30,6 @@
 	</action>
       </actions>
     </install>
-    <readme>Installs RnaChipIntegrator 1.0.0 from PyPI</readme>
+    <readme>Installs RnaChipIntegrator 1.0.1 from PyPI</readme>
   </package>
 </tool_dependency>


### PR DESCRIPTION
PR to update the `rnachipintegrator` tools to use the latest version on PyPI (1.0.1).