### PR TITLE
Update 'trimmomatic' tool to use Trimmomatic 0.36

### DIFF
--- a/tools/trimmomatic/README.rst
+++ b/tools/trimmomatic/README.rst
@@ -33,15 +33,15 @@ by adding the line:
 
     <tool file="trimmomatic/trimmomatic.xml" />
 
-You will also need to install trimmomatic 0.32:
+You will also need to install trimmomatic 0.36:
 
-- http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.32.zip
+- http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.36.zip
 
 The tool wrapper uses the following environment variables in order to find the
 appropriate files:
 
 - ``TRIMMOMATIC_DIR`` should point to the directory holding the
-  ``trimmomatic-0.32.jar`` file
+  ``trimmomatic-0.36.jar`` file
 - ``TRIMMOMATIC_ADAPTERS_DIR`` should point to the directory holding the adapter
   sequence files (used by the ``ILLUMINACLIP`` option).
 
@@ -58,6 +58,7 @@ History
 ========== ======================================================================
 Version    Changes
 ---------- ----------------------------------------------------------------------
+0.36.0     - Update to Trimmomatic 0.36.
 0.32.4     - Add support for ``AVGQUAL`` and ``MAXINFO`` operations.
 0.32.3     - Add support for FASTQ R1/R2 pairs using dataset collections (input
              can be dataset collection, in which case tool also outputs dataset

--- a/tools/trimmomatic/install_tool_deps.sh
+++ b/tools/trimmomatic/install_tool_deps.sh
@@ -16,22 +16,22 @@ if [ ! -d "$TOP_DIR" ] ; then
 fi
 cd $TOP_DIR
 # Trimmomatic 0.32
-INSTALL_DIR=$TOP_DIR/trimmomatic/0.32
+INSTALL_DIR=$TOP_DIR/trimmomatic/0.36
 mkdir -p $INSTALL_DIR
 wd=$(mktemp -d)
 pushd $wd
-wget -q http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.32.zip
-unzip -qq Trimmomatic-0.32.zip
-mv Trimmomatic-0.32/trimmomatic-0.32.jar $INSTALL_DIR/
-mv Trimmomatic-0.32/adapters/ $INSTALL_DIR/
+wget -q http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.36.zip
+unzip -qq Trimmomatic-0.36.zip
+mv Trimmomatic-0.36/trimmomatic-0.36.jar $INSTALL_DIR/
+mv Trimmomatic-0.36/adapters/ $INSTALL_DIR/
 popd
 rm -rf $wd/*
 rmdir $wd
 # Make setup file
-cat > trimmomatic/0.32/env.sh <<EOF
+cat > trimmomatic/0.36/env.sh <<EOF
 #!/bin/sh
-# Source this to setup trimmomatic/0.32
-echo Setting up Trimmomatic 0.32
+# Source this to setup trimmomatic/0.36
+echo Setting up Trimmomatic 0.36
 export TRIMMOMATIC_DIR=$INSTALL_DIR
 export TRIMMOMATIC_ADAPTERS_DIR=$INSTALL_DIR/adapters
 #

--- a/tools/trimmomatic/run_planemo_tests.sh
+++ b/tools/trimmomatic/run_planemo_tests.sh
@@ -13,7 +13,7 @@
 #                         Galaxy instance)
 #
 # List of dependencies
-TOOL_DEPENDENCIES="trimmomatic/0.32"
+TOOL_DEPENDENCIES="trimmomatic/0.36"
 # Where to find them
 TOOL_DEPENDENCIES_DIR=$(pwd)/test.tool_dependencies.trimmomatic
 if [ ! -d $TOOL_DEPENDENCIES_DIR ] ; then

--- a/tools/trimmomatic/tool_dependencies.xml
+++ b/tools/trimmomatic/tool_dependencies.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="trimmomatic" version="0.32">
+    <package name="trimmomatic" version="0.36">
       <install version="1.0">
 	<actions>
-	  <action type="download_by_url">http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.32.zip</action>
+	  <action type="download_by_url">http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.36.zip</action>
 	  <action type="move_file">
-	    <source>trimmomatic-0.32.jar</source>
+	    <source>trimmomatic-0.36.jar</source>
 	    <destination>$INSTALL_DIR</destination>
 	  </action>
           <action type="move_directory_files">

--- a/tools/trimmomatic/trimmomatic.xml
+++ b/tools/trimmomatic/trimmomatic.xml
@@ -1,7 +1,7 @@
-<tool id="trimmomatic" name="Trimmomatic" version="0.32.4">
+<tool id="trimmomatic" name="Trimmomatic" version="0.36.0">
   <description>flexible read trimming tool for Illumina NGS data</description>
   <requirements>
-    <requirement type="package" version="0.32">trimmomatic</requirement>
+    <requirement type="package" version="0.36">trimmomatic</requirement>
   </requirements>
   <stdio>
     <exit_code range="1:" />
@@ -9,7 +9,7 @@
   <command interpreter="bash"><![CDATA[
   trimmomatic.sh
   -mx8G
-  -jar \$TRIMMOMATIC_DIR/trimmomatic-0.32.jar
+  -jar \$TRIMMOMATIC_DIR/trimmomatic-0.36.jar
   #if $paired_end.is_paired_end
     PE -threads \${GALAXY_SLOTS:-6} -phred33
     #set $paired_input_type = $paired_end.paired_input_type_conditional.paired_input_type


### PR DESCRIPTION
PR to update the `trimmomatic` tool to install and run the latest version of Trimmomatic 0.36.