### PR TITLE
Fix Travis-CI failures when planemo fails to install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ install:
 # Bootstrap Galaxy instance for tests
   - "bioinf-software-install/install_galaxy.sh --repo https://github.com/galaxyproject/galaxy/ travis"
   - ". travis/galaxy_venv/bin/activate"
+# Update setuptools before installing planemo
+# See https://github.com/galaxyproject/planemo/issues/520
+  - "pip install --upgrade pip setuptools"
 # Install planemo to do the testing
   - "pip install planemo"
 


### PR DESCRIPTION
PR which fixes failures with the Travis-CI tests due to a problem with installing `planemo` - see https://github.com/galaxyproject/planemo/issues/520 for the background.