### PR TITLE
Remove dependency on galaxy.utils for JSON read/write in CEAS data manager

### DIFF
--- a/tools/ceas/data_manager/data_manager_ceas_fetch_annotations.py
+++ b/tools/ceas/data_manager/data_manager_ceas_fetch_annotations.py
@@ -10,7 +10,11 @@ import urllib2
 import gzip
 import shutil
 
-from galaxy.util.json import from_json_string, to_json_string
+# Convenience functions mapping to JSON conversion
+# (this idiom borrowed from lib/galaxy/utils/json.py)
+import json
+to_json_string = json.dumps
+from_json_string = json.loads
 
 # Download file from specified URL and put into local subdir
 


### PR DESCRIPTION
This PR fixes the bug reported in issue #16, where the CEAS data manager is broken under Galaxy v16.04.