### PR TITLE
Move local tool dependency installation functions into separate files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,3 +51,27 @@ legacy
 The ``legacy`` subdirectory contains tools and packages which are
 no longer supported, or which are backwardly-incompatible, or where
 development is now happening elsewhere.
+
+local_dependency_installers
+---------------------------
+
+The ``local_dependency_installers`` subdirectory contains shell
+scripts with installer functions for many of the tool dependencies.
+
+For example::
+
+    local_dependency_installers/trimmomatic.sh
+
+contains a function ``install_trimmomatic_0_36``, which will install
+Trimmomatic v0.36 in a Galaxy-style directory structure (i.e.
+``.../trimmomatic/0.36/`` which includes an ``env.sh`` which can be
+sourced to make the installed dependency available.
+
+These functions are used primarily for setting up the test environments
+for the Planemo tests, but could be recycled e.g. for local tool
+installations into Galaxy using an appropriately configured
+``galaxy_packages`` dependency resolver (see e.g.
+https://docs.galaxyproject.org/en/master/admin/dependency_resolvers.html#)
+
+Use e.g. ``grep ^function local_dependency_installers/*.sh`` to list
+the available installer functions.

--- a/local_dependency_installers/R.sh
+++ b/local_dependency_installers/R.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+#
+# Install R
+#
+function install_R_3_1_2() {
+    echo Installing R
+    local install_dir=$1/R/3.1.2
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    ##wget -q https://depot.galaxyproject.org/package/linux/x86_64/R/R-3.1.2-Linux-x84_64.tgz
+    ##tar xzf R-3.1.2-Linux-x84_64.tgz
+    ##rm -f R-3.1.2-Linux-x84_64.tgz
+    ##mv * $install_dir
+    wget -q http://cran.r-project.org/src/base/R-3/R-3.1.2.tar.gz
+    tar xzf R-3.1.2.tar.gz
+    cd R-3.1.2
+    ./configure --prefix=$install_dir
+    make
+    make install
+    popd
+    # Clean up
+    rm -rf $wd/*
+    rmdir $wd
+    # Make setup file
+cat > $1/R/3.1.2/env.sh <<EOF
+#!/bin/sh
+# Source this to setup R/3.1.2
+echo Setting up R 3.1.2
+export PATH=$install_dir/bin:\$PATH
+export TCL_LIBRARY=$install_dir/lib/libtcl8.4.so
+export TK_LIBRARY=$install_dir/lib/libtk8.4.so
+#
+EOF
+}

--- a/local_dependency_installers/biopython.sh
+++ b/local_dependency_installers/biopython.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+#
+# Install Biopython
+#
+function install_biopython_1_65() {
+    echo Installing BioPython
+    local install_dir=$1/biopython/1.65
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    pip install --install-option "--prefix=$install_dir" https://pypi.python.org/packages/source/b/biopython/biopython-1.65.tar.gz >/dev/null 2>&1
+    popd
+    rm -rf $wd/*
+    rmdir $wd
+    # Make setup file
+    cat > $1/biopython/1.65/env.sh <<EOF
+#!/bin/sh
+# Source this to setup biopython/1.65
+echo Setting up biopython 1.65
+export PYTHONPATH=$install_dir/lib/python2.7/site-packages:\$PYTHONPATH
+export PYTHONPATH=$install_dir/lib64/python2.7/site-packages:\$PYTHONPATH
+#
+EOF
+}

--- a/local_dependency_installers/bx_python.sh
+++ b/local_dependency_installers/bx_python.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+#
+# Install bx_python
+#
+function install_bx_python_0_7_1() {
+    echo Installing bx_python
+    mkdir -p $1/bx_python
+    local install_dir=$1/bx_python/0.7.1
+    virtualenv $install_dir
+    . $install_dir/bin/activate
+    pip install numpy==1.7.1
+    pip install bx-python==0.7.1
+    deactivate
+    cat > $1/bx_python/0.7.1/env.sh <<EOF
+#!/bin/sh
+# Source this to setup bx_python/0.7.1
+echo Setting up bx_python 0.7.1
+export PYTHONPATH=$install_dir/lib/python2.7/site-packages:\$PYTHONPATH
+#
+EOF
+}
+

--- a/local_dependency_installers/ceas.sh
+++ b/local_dependency_installers/ceas.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+#
+# Install Cistrome CEAS
+#
+function install_cistrome_ceas_1_0_2_d8c0751() {
+    echo Installing Cistrome CEAS
+    local install_dir=$1/cistrome_ceas/1.0.2.d8c0751
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    hg clone https://bitbucket.org/cistrome/cistrome-applications-harvard cistrome_ceas
+    local old_pythonpath=$PYTHONPATH
+    export PYTHONPATH=$PYTHONPATH:$install_dir/lib/python
+    cd cistrome_ceas/published-packages/CEAS/
+    python setup.py install --install-lib $install_dir/lib/python --install-scripts $install_dir/bin
+    popd
+    # Clean up
+    rm -rf $wd/*
+    rmdir $wd
+    export PYTHONPATH=$old_pythonpath
+    # Make setup file
+    cat > $1/cistrome_ceas/1.0.2.d8c0751/env.sh <<EOF
+#!/bin/sh
+# Source this to setup cistrome_ceas/1.0.2.d8c0751/env.sh
+echo Setting up cistrome_ceas 1.0.2.d8c0751
+export PATH=$install_dir/bin:\$PATH
+export PYTHONPATH=$install_dir/lib/python:\$PYTHONPATH
+#
+EOF
+}

--- a/local_dependency_installers/macs2.sh
+++ b/local_dependency_installers/macs2.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+#
+# Install MACS2
+#
+function install_macs2_2_1_0_20140616() {
+    echo Installing MACS2
+    local install_dir=$1/macs/2.1.0.20140616
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    wget -q https://pypi.python.org/packages/source/M/MACS2/MACS2-2.1.0.20140616.tar.gz
+    tar zxf MACS2-2.1.0.20140616.tar.gz
+    local old_pythonpath=$PYTHONPATH
+    export PYTHONPATH=$PYTHONPATH:$install_dir/lib/python
+    cd MACS2-2.1.0.20140616
+    python setup.py install --install-lib $install_dir/lib/python --install-scripts $install_dir/bin
+    popd
+    # Clean up
+    rm -rf $wd/*
+    rmdir $wd
+    export PYTHONPATH=$old_pythonpath
+    # Make setup file
+    cat > $1/macs/2.1.0.20140616/env.sh <<EOF
+#!/bin/sh
+# Source this to setup macs/2.1.0.20140616
+echo Setting up MACS 2.1.0.20140616
+export PATH=$install_dir/bin:\$PATH
+export PYTHONPATH=$install_dir/lib/python:\$PYTHONPATH
+#
+EOF
+}

--- a/local_dependency_installers/numpy.sh
+++ b/local_dependency_installers/numpy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+#
+# Install Numpy
+#
+function install_numpy_1_9() {
+    echo Installing numpy
+    mkdir -p $1/numpy
+    local install_dir=$1/numpy/1.9
+    virtualenv $install_dir
+    . $install_dir/bin/activate
+    pip install numpy==1.9
+    deactivate
+    cat > $1/numpy/1.9/env.sh <<EOF
+#!/bin/sh
+# Source this to setup numpy/1.9
+echo Setting up Numpy 1.9
+export PYTHONPATH=$install_dir/lib/python2.7/site-packages:\$PYTHONPATH
+#
+EOF
+}

--- a/local_dependency_installers/pal_finder.sh
+++ b/local_dependency_installers/pal_finder.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+#
+# Install Pal_finder
+#
+function install_pal_finder_0_02_04() {
+    echo Installing pal_finder
+    local install_dir=$1/pal_finder/0.02.04
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    wget -q http://sourceforge.net/projects/palfinder/files/pal_finder_v0.02.04.tar.gz
+    tar xzf pal_finder_v0.02.04.tar.gz
+    mkdir $install_dir/bin
+    mv pal_finder_v0.02.04/pal_finder_v0.02.04.pl $install_dir/bin
+    mkdir $install_dir/data
+    mv pal_finder_v0.02.04/config.txt $install_dir/data/
+    mv pal_finder_v0.02.04/simple.ref $install_dir/data/
+    popd
+    rm -rf $wd/*
+    rmdir $wd
+    # Make setup file
+    cat > $1/pal_finder/0.02.04/env.sh <<EOF
+#!/bin/sh
+# Source this to setup pal_finder/0.02.04
+echo Setting up pal_finder 0.02.04
+export PATH=$install_dir/bin:\$PATH
+export PALFINDER_SCRIPT_DIR=$install_dir/bin
+export PALFINDER_DATA_DIR=$install_dir/data
+#
+EOF
+}

--- a/local_dependency_installers/pandaseq.sh
+++ b/local_dependency_installers/pandaseq.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+#
+# Install PandaSEQ
+#
+function install_pandaseq_2_8_1() {
+    echo Installing PandaSeq
+    local install_dir=$1/pandaseq/2.8.1
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    wget -q https://github.com/neufeld/pandaseq/archive/v2.8.1.tar.gz
+    tar xzf v2.8.1.tar.gz
+    cd pandaseq-2.8.1
+    ./autogen.sh >/dev/null 2>&1
+    ./configure --prefix=$install_dir >/dev/null 2>&1
+    make; make install >/dev/null 2>&1
+    popd
+    rm -rf $wd/*
+    rmdir $wd
+    # Make setup file
+    cat > $1/pandaseq/2.8.1/env.sh <<EOF
+#!/bin/sh
+# Source this to setup pandaseq/2.8.1
+echo Setting up pandaseq 2.8.1
+export PATH=$install_dir/bin:\$PATH
+export LD_LIBRARY_PATH=$install_dir/lib:\$LD_LIBRARY_PATH
+#
+EOF
+}

--- a/local_dependency_installers/perl.sh
+++ b/local_dependency_installers/perl.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+#
+# Install Perl
+#
+function install_perl_5_16_3() {
+    # Perl 5.16.3
+    echo Installing Perl
+    local install_dir=$1/perl/5.16.3
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    wget -q http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz
+    tar xzf perl-5.16.3.tar.gz
+    cd perl-5.16.3
+    ./Configure -des -Dprefix=$install_dir -D startperl='#!/usr/bin/env perl' >/dev/null 2>&1
+    make install >/dev/null 2>&1
+    popd
+    rm -rf $wd/*
+    rmdir $wd
+    # Make setup file
+    cat > $1/perl/5.16.3/env.sh <<EOF
+#!/bin/sh
+# Source this to setup perl/5.16.3
+echo Setting up perl 5.16.3
+export PATH=$install_dir/bin:\$PATH
+#
+EOF
+}

--- a/local_dependency_installers/primer3_core.sh
+++ b/local_dependency_installers/primer3_core.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -e
+#
+# Install Primer3_core
+#
+function install_primer3_core_2_0_0() {
+    echo Installing primer3_core
+    local install_dir=$1/primer3_core/2.0.0
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    wget -q https://sourceforge.net/projects/primer3/files/primer3/2.0.0-alpha/primer3-2.0.0-alpha.tar.gz
+    tar xzf primer3-2.0.0-alpha.tar.gz
+    cd primer3-2.0.0-alpha
+    make -C src -f Makefile >/dev/null 2>&1
+    mkdir $install_dir/bin
+    mv src/primer3_core $install_dir/bin
+    popd
+    rm -rf $wd/*
+    rmdir $wd
+    # Make setup file
+    cat > $1/primer3_core/2.0.0/env.sh <<EOF
+#!/bin/sh
+# Source this to setup primer3_core/2.0.0
+echo Setting up primer3_core 2.0.0
+export PATH=$install_dir/bin:\$PATH
+#
+EOF
+}

--- a/local_dependency_installers/python_mysql.sh
+++ b/local_dependency_installers/python_mysql.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -e
+#
+# Install python_mysql
+#
+function install_python_mysql_1_2_5() {
+    echo Installing python_mysql
+    local install_dir=$1/python_mysqldb/1.2.5
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    wget -q https://pypi.python.org/packages/source/M/MySQL-python/MySQL-python-1.2.5.zip
+    unzip MySQL-python-1.2.5.zip
+    mkdir -p $install_dir/lib/python
+    local old_pythonpath=$PYTHONPATH
+    export PYTHONPATH=$PYTHONPATH:$install_dir/lib/python
+    cd MySQL-python-1.2.5
+    python setup.py install --install-lib $install_dir/lib/python --install-scripts $install_dir/bin
+    popd
+    # Clean up
+    rm -rf $wd/*
+    rmdir $wd
+    export PYTHONPATH=$old_pythonpath
+    # Make setup file
+    cat > $1/python_mysqldb/1.2.5/env.sh <<EOF
+#!/bin/sh
+# Source this to setup python_mysqldb/1.2.5
+echo Setting up python_mysqldb 1.2.5
+export PATH=$install_dir/bin:\$PATH
+export PYTHONPATH=$install_dir/lib/python:\$PYTHONPATH
+#
+EOF
+}

--- a/local_dependency_installers/rnachipintegrator.sh
+++ b/local_dependency_installers/rnachipintegrator.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+#
+# Install RnaChipIntegrator
+#
+function install_rnachipintegrator_1_0_0() {
+    echo Installing RnaChipIntegrator
+    local version=1.0.0
+    local install_dir=$1/rnachipintegrator/$version
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    wget https://pypi.python.org/packages/source/R/RnaChipIntegrator/RnaChipIntegrator-${version}.tar.gz
+    tar zxf RnaChipIntegrator-${version}.tar.gz
+    cd RnaChipIntegrator-$version
+    pip install --no-use-wheel --install-option "--prefix=$install_dir" .
+    popd
+    rm -rf $wd/*
+    rmdir $wd
+cat > $1/rnachipintegrator/$version/env.sh <<EOF
+#!/bin/sh
+# Source this to setup rnachipintegrator/$version
+echo Setting up RnaChipIntegrator $version
+export PATH=$install_dir/bin:\$PATH
+export PYTHONPATH=$install_dir/lib/python2.7/site-packages:\$PYTHONPATH
+#
+EOF
+}

--- a/local_dependency_installers/trimmomatic.sh
+++ b/local_dependency_installers/trimmomatic.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+#
+# Install the tool dependencies for Trimmomatic
+#
+function install_trimmomatic_0_36() {
+    echo Installing Trimmomatic 0.36
+    local install_dir=$1/trimmomatic/0.36
+    if [ -f $install_dir/env.sh ] ; then
+	return
+    fi
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    wget -q http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.36.zip
+    unzip -qq Trimmomatic-0.36.zip
+    mv Trimmomatic-0.36/trimmomatic-0.36.jar $install_dir/
+    mv Trimmomatic-0.36/adapters/ $install_dir/
+    popd
+    rm -rf $wd/*
+    rmdir $wd
+    # Make setup file
+    cat > $1/trimmomatic/0.36/env.sh <<EOF
+#!/bin/sh
+# Source this to setup trimmomatic/0.36
+echo Setting up Trimmomatic 0.36
+export TRIMMOMATIC_DIR=$install_dir
+export TRIMMOMATIC_ADAPTERS_DIR=$install_dir/adapters
+#
+EOF
+}

--- a/local_dependency_installers/ucsc_tools.sh
+++ b/local_dependency_installers/ucsc_tools.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+#
+# Install UCSC tools and subsets
+#
+function install_ucsc_fetchChromSizes_1_0() {
+    echo Installing UCSC fetchChromSizes 
+    local install_dir=$1/ucsc_fetchChromSizes/1.0
+    mkdir -p $install_dir/bin
+    echo Moving to $install_dir/bin
+    pushd $install_dir/bin
+    wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/fetchChromSizes
+    chmod 755 fetchChromSizes
+    popd
+    # Make setup file
+    cat > $1/ucsc_fetchChromSizes/1.0/env.sh <<EOF
+#!/bin/sh
+# Source this to setup fetchChromSizes/1.0
+echo Setting up fetchChromSizes 1.0
+export PATH=$install_dir/bin:\$PATH
+#
+EOF
+}
+#
+function install_ucsc_tools_for_macs21_1_0() {
+    echo Installing UCSC tools for MACS2
+    local install_dir=$1/ucsc_tools_for_macs21/1.0
+    mkdir -p $install_dir/bin
+    echo Moving to $install_dir/bin
+    pushd $install_dir/bin
+    wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/fetchChromSizes
+    wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/bedClip
+    wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/bedGraphToBigWig
+    for x in "fetchChromSizes bedClip bedGraphToBigWig" ; do
+	chmod 755 $x
+    done
+    popd
+    # Make setup file
+    cat > $1/ucsc_tools_for_macs21/1.0/env.sh <<EOF
+#!/bin/sh
+# Source this to setup ucsc_tools_for_macs21/1.0
+echo Setting up UCSC Tools for MACS21 1.0
+export PATH=$install_dir/bin:\$PATH
+#
+EOF
+}

--- a/local_dependency_installers/weeder.sh
+++ b/local_dependency_installers/weeder.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+#
+# Install Weeder
+#
+function install_weeder_2_0() {
+    echo Installing Weeder2
+    local install_dir=$1/weeder/2.0
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    wget http://159.149.160.51/modtools/downloads/weeder2.0.tar.gz
+    tar xfz weeder2.0.tar.gz
+    g++ weeder2.cpp -o weeder2 -O3
+    mkdir $install_dir/bin
+    mv weeder2 $install_dir/bin
+    mv FreqFiles $install_dir/
+    cd ..
+    popd
+    rm -rf $wd/*
+    rmdir $wd
+    # Make setup file
+    cat > $1/weeder/2.0/env.sh <<EOF
+#!/bin/sh
+# Source this to setup weeder/2.0
+export PATH=$install_dir/bin:\$PATH
+export WEEDER_DIR=$install_dir
+export WEEDER_FREQFILES_DIR=$install_dir/FreqFiles
+#
+EOF
+}

--- a/local_dependency_installers/xlsxwriter.sh
+++ b/local_dependency_installers/xlsxwriter.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+#
+# Install XlsxWriter
+#
+function install_xlsxwriter_0_8_4() {
+    echo Installing XlsxWriter
+    local version=1.0.0
+    local install_dir=$1/xlsxwriter/0.8.4
+    mkdir -p $install_dir
+    local wd=$(mktemp -d)
+    echo Moving to $wd
+    pushd $wd
+    wget -q https://pypi.python.org/packages/source/X/XlsxWriter/XlsxWriter-0.8.4.tar.gz
+    tar xzf XlsxWriter-0.8.4.tar.gz
+    cd XlsxWriter-0.8.4
+    OLD_PYTHONPATH=$PYTHONPATH
+    mkdir -p $install_dir/lib/python
+    export PYTHONPATH=$PYTHONPATH:$install_dir/lib/python
+    python setup.py install --install-lib $install_dir/lib/python --install-scripts $install_dir/bin
+    popd
+    rm -rf $wd/*
+    rmdir $wd
+    export PYTHONPATH=$OLD_PYTHONPATH
+    cat > $1/xlsxwriter/0.8.4/env.sh <<EOF
+#!/bin/sh
+# Source this to setup xlsxwriter/0.8.4
+echo Setting up xlsxwriter 0.8.4
+export PYTHONPATH=$install_dir/lib/python:\$PYTHONPATH
+export PATH=$install_dir/bin:\$PATH
+#
+EOF
+}

--- a/tools/ceas/install_tool_deps.sh
+++ b/tools/ceas/install_tool_deps.sh
@@ -2,6 +2,13 @@
 #
 # Install the tool dependencies for CEAS for testing from command line
 #
+# Installer functions
+. $(dirname $0)/../../local_dependency_installers/bx_python.sh
+. $(dirname $0)/../../local_dependency_installers/python_mysql.sh
+. $(dirname $0)/../../local_dependency_installers/ceas.sh
+. $(dirname $0)/../../local_dependency_installers/R.sh
+. $(dirname $0)/../../local_dependency_installers/ucsc_tools.sh
+#
 # Installation directory
 TOP_DIR=$1
 if [ -z "$TOP_DIR" ] ; then
@@ -14,113 +21,15 @@ fi
 if [ ! -d "$TOP_DIR" ] ; then
     mkdir -p $TOP_DIR
 fi
-cd $TOP_DIR
 # bx_python 0.7.1
-mkdir bx_python
-virtualenv bx_python/0.7.1
-. bx_python/0.7.1/bin/activate
-pip install numpy==1.7.1
-pip install bx-python==0.7.1
-deactivate
-cat > bx_python/0.7.1/env.sh <<EOF
-#!/bin/sh
-# Source this to setup bx_python/0.7.1
-echo Setting up bx_python 0.7.1
-export PYTHONPATH=$TOP_DIR/bx_python/0.7.1/lib/python2.7/site-packages:\$PYTHONPATH
-#
-EOF
+install_bx_python_0_7_1 $TOP_DIR
 # python_mysqldb 1.2.5
-INSTALL_DIR=$TOP_DIR/python_mysqldb/1.2.5
-mkdir -p $INSTALL_DIR/lib/python
-wd=$(mktemp -d)
-pushd $wd
-wget -q https://pypi.python.org/packages/source/M/MySQL-python/MySQL-python-1.2.5.zip
-unzip MySQL-python-1.2.5.zip
-OLD_PYTHONPATH=$PYTHONPATH
-export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python
-cd MySQL-python-1.2.5
-python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
-popd
-# Clean up
-rm -rf $wd/*
-rmdir $wd
-export PYTHONPATH=$OLD_PYTHONPATH
-# Make setup file
-cat > python_mysqldb/1.2.5/env.sh <<EOF
-#!/bin/sh
-# Source this to setup python_mysqldb/1.2.5
-echo Setting up python_mysqldb 1.2.5
-export PATH=$INSTALL_DIR/bin:\$PATH
-export PYTHONPATH=$INSTALL_DIR/lib/python:\$PYTHONPATH
-#
-EOF
+install_python_mysql_1_2_5 $TOP_DIR
 # cistrome_ceas 1.0.2.d8c0751
-INSTALL_DIR=$TOP_DIR/cistrome_ceas/1.0.2.d8c0751
-mkdir -p $INSTALL_DIR/lib/python
-wd=$(mktemp -d)
-pushd $wd
-hg clone https://bitbucket.org/cistrome/cistrome-applications-harvard cistrome_ceas
-OLD_PYTHONPATH=$PYTHONPATH
-export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python
-cd cistrome_ceas/published-packages/CEAS/
-python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
-popd
-# Clean up
-rm -rf $wd/*
-rmdir $wd
-export PYTHONPATH=$OLD_PYTHONPATH
-# Make setup file
-cat > cistrome_ceas/1.0.2.d8c0751/env.sh <<EOF
-#!/bin/sh
-# Source this to setup cistrome_ceas/1.0.2.d8c0751/env.sh
-echo Setting up cistrome_ceas 1.0.2.d8c0751
-export PATH=$INSTALL_DIR/bin:\$PATH
-export PYTHONPATH=$INSTALL_DIR/lib/python:\$PYTHONPATH
-#
-EOF
+install_cistrome_ceas_1_0_2_d8c0751 $TOP_DIR
 # R 3.1.2
-INSTALL_DIR=$TOP_DIR/R/3.1.2
-mkdir -p $INSTALL_DIR
-wd=$(mktemp -d)
-pushd $wd
-##wget -q https://depot.galaxyproject.org/package/linux/x86_64/R/R-3.1.2-Linux-x84_64.tgz
-##tar xzf R-3.1.2-Linux-x84_64.tgz
-##rm -f R-3.1.2-Linux-x84_64.tgz
-##mv * $INSTALL_DIR
-wget -q http://cran.r-project.org/src/base/R-3/R-3.1.2.tar.gz
-tar xzf R-3.1.2.tar.gz
-cd R-3.1.2
-./configure --prefix=$INSTALL_DIR
-make
-make install
-popd
-# Clean up
-rm -rf $wd/*
-rmdir $wd
-# Make setup file
-cat > R/3.1.2/env.sh <<EOF
-#!/bin/sh
-# Source this to setup R/3.1.2
-echo Setting up R 3.1.2
-export PATH=$INSTALL_DIR/bin:\$PATH
-export TCL_LIBRARY=$INSTALL_DIR/lib/libtcl8.4.so
-export TK_LIBRARY=$INSTALL_DIR/lib/libtk8.4.so
-#
-EOF
+install_R_3_1_2 $TOP_DIR
 # fetchChromSizes (UCSC tool)
-INSTALL_DIR=$TOP_DIR/ucsc_fetchChromSizes/1.0
-mkdir -p $INSTALL_DIR/bin
-cd $INSTALL_DIR/bin
-wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/fetchChromSizes
-chmod 755 fetchChromSizes
-cd $TOP_DIR
-# Make setup file
-cat > ucsc_fetchChromSizes/1.0/env.sh <<EOF
-#!/bin/sh
-# Source this to setup fetchChromSizes/1.0
-echo Setting up fetchChromSizes 1.0
-export PATH=$INSTALL_DIR/bin:\$PATH
-#
-EOF
+install_ucsc_fetchChromSizes_1_0 $TOP_DIR
 ##
 #

--- a/tools/macs21/install_tool_deps.sh
+++ b/tools/macs21/install_tool_deps.sh
@@ -2,6 +2,11 @@
 #
 # Install the tool dependencies for MACS21 for testing from command line
 #
+# Installer functions
+. $(dirname $0)/../../local_dependency_installers/numpy.sh
+. $(dirname $0)/../../local_dependency_installers/macs2.sh
+. $(dirname $0)/../../local_dependency_installers/ucsc_tools.sh
+#
 # Installation directory
 TOP_DIR=$1
 if [ -z "$TOP_DIR" ] ; then
@@ -14,64 +19,12 @@ fi
 if [ ! -d "$TOP_DIR" ] ; then
     mkdir -p $TOP_DIR
 fi
-cd $TOP_DIR
 # Numpy 1.9
-mkdir numpy
-virtualenv numpy/1.9
-. numpy/1.9/bin/activate
-pip install numpy==1.9
-deactivate
-cat > numpy/1.9/env.sh <<EOF
-#!/bin/sh
-# Source this to setup numpy/1.9
-echo Setting up Numpy 1.9
-export PYTHONPATH=$TOP_DIR/numpy/1.9/lib/python2.7/site-packages:\$PYTHONPATH
-#
-EOF
+install_numpy_1_9 $TOP_DIR
 # MACS21
-. numpy/1.9/env.sh # needs Numpy 1.9
-INSTALL_DIR=$TOP_DIR/macs/2.1.0.20140616
-mkdir -p $INSTALL_DIR/lib/python
-wd=$(mktemp -d)
-pushd $wd
-wget -q https://pypi.python.org/packages/source/M/MACS2/MACS2-2.1.0.20140616.tar.gz
-tar zxf MACS2-2.1.0.20140616.tar.gz
-OLD_PYTHONPATH=$PYTHONPATH
-export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python
-cd MACS2-2.1.0.20140616
-python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
-popd
-# Clean up
-rm -rf $wd/*
-rmdir $wd
-export PYTHONPATH=$OLD_PYTHONPATH
-# Make setup file
-cat > macs/2.1.0.20140616/env.sh <<EOF
-#!/bin/sh
-# Source this to setup macs/2.1.0.20140616
-echo Setting up MACS 2.1.0.20140616
-export PATH=$INSTALL_DIR/bin:\$PATH
-export PYTHONPATH=$INSTALL_DIR/lib/python:\$PYTHONPATH
-#
-EOF
+. $TOP_DIR/numpy/1.9/env.sh # needs Numpy 1.9
+install_macs2_2_1_0_20140616 $TOP_DIR
 # UCSC tool subset
-INSTALL_DIR=$TOP_DIR/ucsc_tools_for_macs21/1.0
-mkdir -p $INSTALL_DIR/bin
-cd $INSTALL_DIR/bin
-wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/fetchChromSizes
-wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/bedClip
-wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/bedGraphToBigWig
-for x in "fetchChromSizes bedClip bedGraphToBigWig" ; do
-    chmod 755 $x
-done
-cd $TOP_DIR
-# Make setup file
-cat > ucsc_tools_for_macs21/1.0/env.sh <<EOF
-#!/bin/sh
-# Source this to setup ucsc_tools_for_macs21/1.0
-echo Setting up UCSC Tools for MACS21 1.0
-export PATH=$INSTALL_DIR/bin:\$PATH
-#
-EOF
+install_ucsc_tools_for_macs21_1_0 $TOP_DIR
 ##
 #

--- a/tools/pal_finder/install_tool_deps.sh
+++ b/tools/pal_finder/install_tool_deps.sh
@@ -2,6 +2,12 @@
 #
 # Install the tool dependencies for pal_finder for testing from command line
 #
+# Installer functions
+. $(dirname $0)/../../local_dependency_installers/perl.sh
+. $(dirname $0)/../../local_dependency_installers/primer3_core.sh
+. $(dirname $0)/../../local_dependency_installers/pal_finder.sh
+. $(dirname $0)/../../local_dependency_installers/biopython.sh
+. $(dirname $0)/../../local_dependency_installers/pandaseq.sh
 # Installation directory
 TOP_DIR=$1
 if [ -z "$TOP_DIR" ] ; then
@@ -14,125 +20,15 @@ fi
 if [ ! -d "$TOP_DIR" ] ; then
     mkdir -p $TOP_DIR
 fi
-cd $TOP_DIR
 # Perl 5.16.3
-echo Installing Perl
-INSTALL_DIR=$TOP_DIR/perl/5.16.3
-mkdir -p $INSTALL_DIR
-wd=$(mktemp -d)
-echo Moving to $wd
-pushd $wd
-wget -q http://www.cpan.org/src/5.0/perl-5.16.3.tar.gz
-tar xzf perl-5.16.3.tar.gz
-cd perl-5.16.3
-./Configure -des -Dprefix=$INSTALL_DIR -D startperl='#!/usr/bin/env perl' >/dev/null 2>&1
-make install >/dev/null 2>&1
-popd
-rm -rf $wd/*
-rmdir $wd
-# Make setup file
-cat > perl/5.16.3/env.sh <<EOF
-#!/bin/sh
-# Source this to setup perl/5.16.3
-echo Setting up perl 5.16.3
-export PATH=$INSTALL_DIR/bin:\$PATH
-#
-EOF
-# primer3_core3
-echo Installing primer3_core
-INSTALL_DIR=$TOP_DIR/primer3_core/2.0.0
-mkdir -p $INSTALL_DIR
-wd=$(mktemp -d)
-echo Moving to $wd
-pushd $wd
-wget -q https://sourceforge.net/projects/primer3/files/primer3/2.0.0-alpha/primer3-2.0.0-alpha.tar.gz
-tar xzf primer3-2.0.0-alpha.tar.gz
-cd primer3-2.0.0-alpha
-make -C src -f Makefile >/dev/null 2>&1
-mkdir $INSTALL_DIR/bin
-mv src/primer3_core $INSTALL_DIR/bin
-popd
-rm -rf $wd/*
-rmdir $wd
-# Make setup file
-cat > primer3_core/2.0.0/env.sh <<EOF
-#!/bin/sh
-# Source this to setup primer3_core/2.0.0
-echo Setting up primer3_core 2.0.0
-export PATH=$INSTALL_DIR/bin:\$PATH
-#
-EOF
+install_perl_5_16_3 $TOP_DIR
+# primer3_core 2.0.0
+install_primer3_core_2_0_0 $TOP_DIR
 # Pal_finder 0.02.04
-echo Installing pal_finder
-INSTALL_DIR=$TOP_DIR/pal_finder/0.02.04
-mkdir -p $INSTALL_DIR
-wd=$(mktemp -d)
-echo Moving to $wd
-pushd $wd
-wget -q http://sourceforge.net/projects/palfinder/files/pal_finder_v0.02.04.tar.gz
-tar xzf pal_finder_v0.02.04.tar.gz
-mkdir $INSTALL_DIR/bin
-mv pal_finder_v0.02.04/pal_finder_v0.02.04.pl $INSTALL_DIR/bin
-mkdir $INSTALL_DIR/data
-mv pal_finder_v0.02.04/config.txt $INSTALL_DIR/data/
-mv pal_finder_v0.02.04/simple.ref $INSTALL_DIR/data/
-popd
-rm -rf $wd/*
-rmdir $wd
-# Make setup file
-cat > pal_finder/0.02.04/env.sh <<EOF
-#!/bin/sh
-# Source this to setup pal_finder/0.02.04
-echo Setting up pal_finder 0.02.04
-export PATH=$INSTALL_DIR/bin:\$PATH
-export PALFINDER_SCRIPT_DIR=$INSTALL_DIR/bin
-export PALFINDER_DATA_DIR=$INSTALL_DIR/data
-#
-EOF
+install_pal_finder_0_02_04 $TOP_DIR
 # BioPython 1.65
-echo Installing BioPython
-INSTALL_DIR=$TOP_DIR/biopython/1.65
-mkdir -p $INSTALL_DIR
-wd=$(mktemp -d)
-echo Moving to $wd
-pushd $wd
-pip install --install-option "--prefix=$INSTALL_DIR" https://pypi.python.org/packages/source/b/biopython/biopython-1.65.tar.gz >/dev/null 2>&1
-popd
-rm -rf $wd/*
-rmdir $wd
-# Make setup file
-cat > biopython/1.65/env.sh <<EOF
-#!/bin/sh
-# Source this to setup biopython/1.65
-echo Setting up biopython 1.65
-export PYTHONPATH=$INSTALL_DIR/lib/python2.7/site-packages:\$PYTHONPATH
-export PYTHONPATH=$INSTALL_DIR/lib64/python2.7/site-packages:\$PYTHONPATH
-#
-EOF
+install_biopython_1_65 $TOP_DIR
 # PandaSeq 2.8
-echo Installing PandaSeq
-INSTALL_DIR=$TOP_DIR/pandaseq/2.8.1
-mkdir -p $INSTALL_DIR
-wd=$(mktemp -d)
-echo Moving to $wd
-pushd $wd
-wget -q https://github.com/neufeld/pandaseq/archive/v2.8.1.tar.gz
-tar xzf v2.8.1.tar.gz
-cd pandaseq-2.8.1
-./autogen.sh >/dev/null 2>&1
-./configure --prefix=$INSTALL_DIR >/dev/null 2>&1
-make; make install >/dev/null 2>&1
-popd
-rm -rf $wd/*
-rmdir $wd
-# Make setup file
-cat > pandaseq/2.8.1/env.sh <<EOF
-#!/bin/sh
-# Source this to setup pandaseq/2.8.1
-echo Setting up pandaseq 2.8.1
-export PATH=$INSTALL_DIR/bin:\$PATH
-export LD_LIBRARY_PATH=$INSTALL_DIR/lib:\$LD_LIBRARY_PATH
-#
-EOF
+install_pandaseq_2_8_1 $TOP_DIR
 ##
 #

--- a/tools/rnachipintegrator/install_tool_deps.sh
+++ b/tools/rnachipintegrator/install_tool_deps.sh
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 #
 # Install the tool dependencies for RnaChipIntegrator for testing from command line
+# Installer functions
+. $(dirname $0)/../../local_dependency_installers/rnachipintegrator.sh
+. $(dirname $0)/../../local_dependency_installers/xlsxwriter.sh
 #
 # Installation directory
 TOP_DIR=$1
@@ -14,51 +17,9 @@ fi
 if [ ! -d "$TOP_DIR" ] ; then
     mkdir -p $TOP_DIR
 fi
-cd $TOP_DIR
 # RnaChipIntegrator 1.0.0
-VERSION=1.0.0
-INSTALL_DIR=$TOP_DIR/rnachipintegrator/$VERSION
-mkdir -p $INSTALL_DIR
-wd=$(mktemp -d)
-pushd $wd
-wget https://pypi.python.org/packages/source/R/RnaChipIntegrator/RnaChipIntegrator-${VERSION}.tar.gz
-tar zxf RnaChipIntegrator-${VERSION}.tar.gz
-cd RnaChipIntegrator-$VERSION
-pip install --no-use-wheel --install-option "--prefix=$INSTALL_DIR" .
-popd
-rm -rf $wd/*
-rmdir $wd
-cat > rnachipintegrator/$VERSION/env.sh <<EOF
-#!/bin/sh
-# Source this to setup rnachipintegrator/$VERSION
-echo Setting up RnaChipIntegrator $VERSION
-export PATH=$INSTALL_DIR/bin:\$PATH
-export PYTHONPATH=$INSTALL_DIR/lib/python2.7/site-packages:\$PYTHONPATH
-#
-EOF
+install_rnachipintegrator_1_0_0 $TOP_DIR
 # xlsxwriter 0.8.4
-INSTALL_DIR=$TOP_DIR/xlsxwriter/0.8.4
-mkdir -p $INSTALL_DIR
-wd=$(mktemp -d)
-pushd $wd
-wget -q https://pypi.python.org/packages/source/X/XlsxWriter/XlsxWriter-0.8.4.tar.gz
-tar xzf XlsxWriter-0.8.4.tar.gz
-cd XlsxWriter-0.8.4
-OLD_PYTHONPATH=$PYTHONPATH
-mkdir -p $INSTALL_DIR/lib/python
-export PYTHONPATH=$PYTHONPATH:$INSTALL_DIR/lib/python
-python setup.py install --install-lib $INSTALL_DIR/lib/python --install-scripts $INSTALL_DIR/bin
-popd
-rm -rf $wd/*
-rmdir $wd
-export PYTHONPATH=$OLD_PYTHONPATH
-cat > xlsxwriter/0.8.4/env.sh <<EOF
-#!/bin/sh
-# Source this to setup xlsxwriter/0.8.4
-echo Setting up xlsxwriter 0.8.4
-export PYTHONPATH=$INSTALL_DIR/lib/python:\$PYTHONPATH
-export PATH=$INSTALL_DIR/bin:\$PATH
-#
-EOF
+install_xlsxwriter_0_8_4 $TOP_DIR
 ##
 #

--- a/tools/trimmomatic/install_tool_deps.sh
+++ b/tools/trimmomatic/install_tool_deps.sh
@@ -2,6 +2,8 @@
 #
 # Install dependencies for Trimmomatic for testing from the command line
 #
+# Installer functions
+. $(dirname $0)/../../local_dependency_installers/trimmomatic.sh
 # Installation directory
 TOP_DIR=$1
 if [ -z "$TOP_DIR" ] ; then
@@ -14,27 +16,7 @@ fi
 if [ ! -d "$TOP_DIR" ] ; then
     mkdir -p $TOP_DIR
 fi
-cd $TOP_DIR
 # Trimmomatic 0.32
-INSTALL_DIR=$TOP_DIR/trimmomatic/0.36
-mkdir -p $INSTALL_DIR
-wd=$(mktemp -d)
-pushd $wd
-wget -q http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.36.zip
-unzip -qq Trimmomatic-0.36.zip
-mv Trimmomatic-0.36/trimmomatic-0.36.jar $INSTALL_DIR/
-mv Trimmomatic-0.36/adapters/ $INSTALL_DIR/
-popd
-rm -rf $wd/*
-rmdir $wd
-# Make setup file
-cat > trimmomatic/0.36/env.sh <<EOF
-#!/bin/sh
-# Source this to setup trimmomatic/0.36
-echo Setting up Trimmomatic 0.36
-export TRIMMOMATIC_DIR=$INSTALL_DIR
-export TRIMMOMATIC_ADAPTERS_DIR=$INSTALL_DIR/adapters
-#
-EOF
+install_trimmomatic_0_36 $TOP_DIR
 ##
 #

--- a/tools/weeder2/install_tool_deps.sh
+++ b/tools/weeder2/install_tool_deps.sh
@@ -2,6 +2,9 @@
 #
 # Install the tool dependencies for Weeder2 for testing from command line
 #
+# Installer functions
+. $(dirname $0)/../../local_dependency_installers/weeder.sh
+#
 # Installation directory
 TOP_DIR=$1
 if [ -z "$TOP_DIR" ] ; then
@@ -14,30 +17,7 @@ fi
 if [ ! -d "$TOP_DIR" ] ; then
     mkdir -p $TOP_DIR
 fi
-cd $TOP_DIR
 # Weeder 2.0
-INSTALL_DIR=$TOP_DIR/weeder/2.0
-mkdir -p $INSTALL_DIR
-wd=$(mktemp -d)
-pushd $wd
-wget http://159.149.160.51/modtools/downloads/weeder2.0.tar.gz
-tar xfz weeder2.0.tar.gz
-g++ weeder2.cpp -o weeder2 -O3
-mkdir $INSTALL_DIR/bin
-mv weeder2 $INSTALL_DIR/bin
-mv FreqFiles $INSTALL_DIR/
-cd ..
-popd
-rm -rf $wd/*
-rmdir $wd
-# Make setup file
-cat > weeder/2.0/env.sh <<EOF
-#!/bin/sh
-# Source this to setup weeder/2.0
-export PATH=$INSTALL_DIR/bin:\$PATH
-export WEEDER_DIR=$INSTALL_DIR
-export WEEDER_FREQFILES_DIR=$INSTALL_DIR/FreqFiles
-#
-EOF
+install_weeder_2_0 $TOP_DIR
 ##
 #


### PR DESCRIPTION
PR to move the script functionality which performs local installation of tool dependencies for testing into separate files, in order to facilitate allow reuse (e.g. for local installation of dependencies into a Galaxy instance).

The idea is that installer functions will be grouped into files in the `local_dependency_installers` directory, e.g.:

    .../local_dependency_installers/trimmomatic.sh

The installer script will source the files that it needs and then invoke the appropriate functions, e.g.:

    ...
    # Load function for trimmomatic installations
    . $(dirname $0)/../../local_dependency_installers/trimmomatic.sh
    ...
    # Invoke installer function for Trimmomatic 0.36
    install_trimmomatic_0_36 $LOCAL_TOOL_DEPS_DIR
    ...