### PR TITLE
Get CEAS tool dependencies for R and bx-python from toolshed

### DIFF
--- a/tools/ceas/README.rst
+++ b/tools/ceas/README.rst
@@ -67,6 +67,8 @@ History
 ========== ======================================================================
 Version    Changes
 ---------- ----------------------------------------------------------------------
+1.0.2-3    - Switch to getting R 3.1.2 and bx-python 0.7.1 dependencies from the
+             toolshed (rather than installing as part of the tool)
 1.0.2-2    - Major updates to fix various bugs, add tests and enable ceasBW to
              be used without an existing chromosome sizes file.
 1.0.2-1    - Modified to work with Cistrome-version of CEAS (includes additional

--- a/tools/ceas/ceas_wrapper.xml
+++ b/tools/ceas/ceas_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="ceas" name="CEAS" version="1.0.2-2">
+<tool id="ceas" name="CEAS" version="1.0.2-3">
   <description>Annotate intervals and scores with genome features</description>
   <requirements>
     <requirement type="package" version="1.2.5">python_mysqldb</requirement>

--- a/tools/ceas/ceas_wrapper.xml
+++ b/tools/ceas/ceas_wrapper.xml
@@ -2,7 +2,7 @@
   <description>Annotate intervals and scores with genome features</description>
   <requirements>
     <requirement type="package" version="1.2.5">python_mysqldb</requirement>
-    <requirement type="package" version="0.7.1">bx_python</requirement>
+    <requirement type="package" version="0.7.1">bx-python</requirement>
     <requirement type="package" version="1.0.2.d8c0751">cistrome_ceas</requirement>
     <requirement type="package" version="1.0">ucsc_fetchChromSizes</requirement>
     <requirement type="package" version="3.1.2">R</requirement>

--- a/tools/ceas/tool_dependencies.xml
+++ b/tools/ceas/tool_dependencies.xml
@@ -4,6 +4,10 @@
   <package name="R" version="3.1.2">
     <repository name="package_r_3_1_2" prior_installation_required="True" owner="iuc" />
   </package>
+  <!-- bx_python from main/test toolshed -->
+  <package name="bx-python" version="0.7.1">
+    <repository name="package_bx_python_0_7" prior_installation_required="True" owner="iuc" />
+  </package>
   <!-- Python mysqldb package -->
   <package name="python_mysqldb" version="1.2.5">
     <install version="1.0">
@@ -21,28 +25,6 @@
       </actions>
     </install>
     <readme>Installs Python module MySQLdb 1.2.5</readme>
-  </package>
-  <!-- bx_python
-       This is cribbed from devteam's 'package_bx_python_0_7' in the main
-       toolshed:
-       https://toolshed.g2.bx.psu.edu/view/devteam/package_bx_python_0_7
-  -->
-  <package name="bx_python" version="0.7.1">
-    <install version="1.0">
-      <actions>
-        <action type="setup_virtualenv">
-numpy==1.7.1
-bx-python==0.7.1
-        </action>
-        <action type="set_environment">
-          <environment_variable action="set_to" name="BX_PYTHON_PATH">$INSTALL_DIR</environment_variable>
-        </action>
-      </actions>
-    </install>
-    <readme>
-      Installation of bx-python 0.7.1 along with numpy 1.7.1. The installation can be
-      accessed via BX_PYTHON_PATH.
-    </readme>
   </package>
   <!-- cistrome_ceas
        Installs the version of CEAS package found in the Cistrome

--- a/tools/ceas/tool_dependencies.xml
+++ b/tools/ceas/tool_dependencies.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0"?>
 <tool_dependency>
-  <!-- Local version of R 3.1.2 dependency -->
+  <!-- R 3.1.2 from main/test toolshed -->
   <package name="R" version="3.1.2">
-    <install version="1.0">
-      <actions>
-	<action type="download_by_url">http://cran.r-project.org/src/base/R-3/R-3.1.2.tar.gz</action>
-        <action type="shell_command">./configure --prefix=$INSTALL_DIR</action>
-        <action type="make_install" />
-        <action type="set_environment">
-          <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR/bin</environment_variable>
-        </action>
-      </actions>
-    </install>
+    <repository name="package_r_3_1_2" prior_installation_required="True" owner="iuc" />
   </package>
   <!-- Python mysqldb package -->
   <package name="python_mysqldb" version="1.2.5">


### PR DESCRIPTION
PR that updates the `ceas` tool dependencies so that `R` and `bx-python` are installed from the toolshed rather than by the tool.
