### PR TITLE
Fix macs21 bigWig generation and termination on error

### DIFF
--- a/local_dependency_installers/ucsc_tools.sh
+++ b/local_dependency_installers/ucsc_tools.sh
@@ -43,3 +43,27 @@ export PATH=$install_dir/bin:\$PATH
 #
 EOF
 }
+#
+function install_ucsc_tools_for_macs21_2_0() {
+    echo Installing UCSC tools for MACS2
+    local install_dir=$1/ucsc_tools_for_macs21/2.0
+    mkdir -p $install_dir/bin
+    echo Moving to $install_dir/bin
+    pushd $install_dir/bin
+    wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/fetchChromSizes
+    wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/bedClip
+    wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/bedSort
+    wget -q http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/bedGraphToBigWig
+    for x in "fetchChromSizes bedClip bedSort bedGraphToBigWig" ; do
+	chmod 755 $x
+    done
+    popd
+    # Make setup file
+    cat > $1/ucsc_tools_for_macs21/2.0/env.sh <<EOF
+#!/bin/sh
+# Source this to setup ucsc_tools_for_macs21/2.0
+echo Setting up UCSC Tools for MACS21 2.0
+export PATH=$install_dir/bin:\$PATH
+#
+EOF
+}

--- a/tools/macs21/README.rst
+++ b/tools/macs21/README.rst
@@ -59,6 +59,8 @@ practices in invoking commands from Galaxy, and to add new functionality.
 ========== ======================================================================
 Version    Changes
 ---------- ----------------------------------------------------------------------
+2.1.0-6    - Add bedSort step into bigWig file generation; terminate with error
+             when MACS finishes with non-zero exit code.
 2.1.0-5    - User must explicitly specify the format for the inputs (to allow
              for paired-end data)
 2.1.0-4    - Remove 'bdgcmp' functionality.

--- a/tools/macs21/install_tool_deps.sh
+++ b/tools/macs21/install_tool_deps.sh
@@ -25,6 +25,6 @@ install_numpy_1_9 $TOP_DIR
 . $TOP_DIR/numpy/1.9/env.sh # needs Numpy 1.9
 install_macs2_2_1_0_20140616 $TOP_DIR
 # UCSC tool subset
-install_ucsc_tools_for_macs21_1_0 $TOP_DIR
+install_ucsc_tools_for_macs21_2_0 $TOP_DIR
 ##
 #

--- a/tools/macs21/macs21_wrapper.py
+++ b/tools/macs21/macs21_wrapper.py
@@ -219,6 +219,10 @@ if __name__ == "__main__":
     proc = subprocess.Popen(args=cmdline,shell=True,cwd=working_dir,
                             stderr=open(stderr_filen,'wb'))
     proc.wait()
+    exit_code = proc.returncode
+    if exit_code != 0:
+        sys.stderr.write(open(stderr_filen,'rb').read())
+        sys.exit(exit_code)
     
     # Run R script to create PDF from model script
     if os.path.exists(os.path.join(working_dir,"%s_model.r" % experiment_name)):

--- a/tools/macs21/macs21_wrapper.py
+++ b/tools/macs21/macs21_wrapper.py
@@ -61,7 +61,8 @@ def make_bigwig_from_bedgraph(bedgraph_file,bigwig_file,
 
     $ fetchChromSizes.sh mm9 > mm9.chrom.sizes
     $ bedClip treat.bedgraph mm9.chrom.sizes treat.clipped
-    $ bedGraphToBigWig treat.clipped mm9.chrom.sizes treat.bw
+    $ bedSort treat.clipped treat.clipped.sorted
+    $ bedGraphToBigWig treat.clipped.sorted mm9.chrom.sizes treat.bw
 
     Get the binaries from
     http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/
@@ -111,8 +112,20 @@ def make_bigwig_from_bedgraph(bedgraph_file,bigwig_file,
     if not os.path.exists(treat_clipped):
         sys.stderr.write("Failed to create clipped bed file\n")
         sys.exit(1)
+    # Run bedSort
+    treat_clipped_sorted = "%s.sorted" % os.path.basename(treat_clipped)
+    cmd = "bedSort %s %s" % (treat_clipped,treat_clipped_sorted)
+    print "Running %s" % cmd
+    proc = subprocess.Popen(args=cmd,shell=True,cwd=working_dir)
+    proc.wait()
+    # Check that sorted file exists
+    treat_clipped_sorted = os.path.join(working_dir,treat_clipped_sorted)
+    if not os.path.exists(treat_clipped_sorted):
+        sys.stderr.write("Failed to create sorted clipped bed file\n")
+        sys.exit(1)
     # Run bedGraphToBigWig
-    cmd = "bedGraphToBigWig %s %s %s" % (treat_clipped,chrom_sizes,
+    cmd = "bedGraphToBigWig %s %s %s" % (treat_clipped_sorted,
+                                         chrom_sizes,
                                          bigwig_file)
     print "Running %s" % cmd
     proc = subprocess.Popen(args=cmd,shell=True,cwd=working_dir)

--- a/tools/macs21/macs21_wrapper.xml
+++ b/tools/macs21/macs21_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="macs2_1_peakcalling" name="MACS2.1.0" version="2.1.0-5">
+<tool id="macs2_1_peakcalling" name="MACS2.1.0" version="2.1.0-6">
   <description>Model-based Analysis of ChIP-Seq: peak calling</description>
   <requirements>
     <requirement type="package" version="2.7">python</requirement>

--- a/tools/macs21/macs21_wrapper.xml
+++ b/tools/macs21/macs21_wrapper.xml
@@ -5,7 +5,7 @@
     <requirement type="package" version="1.9">numpy</requirement>
     <requirement type="package" version="2.1.0.20140616">macs2</requirement>
     <requirement type="package" version="3.1.2">R</requirement>
-    <requirement type="package" version="1.0">ucsc_tools_for_macs21</requirement>
+    <requirement type="package" version="2.0">ucsc_tools_for_macs21</requirement>
   </requirements>
   <version_command>macs2 --version</version_command>
   <command interpreter="python">

--- a/tools/macs21/run_planemo_tests.sh
+++ b/tools/macs21/run_planemo_tests.sh
@@ -15,7 +15,7 @@
 # List of dependencies
 TOOL_DEPENDENCIES="numpy/1.9
  macs/2.1.0.20140616 
- ucsc_tools_for_macs21/1.0"
+ ucsc_tools_for_macs21/2.0"
 # Where to find them
 TOOL_DEPENDENCIES_DIR=$(pwd)/test.tool_dependencies.macs21
 if [ ! -d $TOOL_DEPENDENCIES_DIR ] ; then

--- a/tools/macs21/tool_dependencies.xml
+++ b/tools/macs21/tool_dependencies.xml
@@ -8,7 +8,7 @@
     <repository name="package_r_3_1_2" prior_installation_required="True" owner="iuc" />
   </package>
   <!-- Subset of UCSC tools -->
-  <package name="ucsc_tools_for_macs21" version="1.0">
+  <package name="ucsc_tools_for_macs21" version="2.0">
       <install version="1.0">
             <actions>
 	      <!-- fetchChromSizes -->
@@ -24,6 +24,13 @@
               </action>
               <action type="chmod">
                 <file mode="755">$INSTALL_DIR/bedClip</file>
+              </action>
+	      <!-- bedSort -->
+              <action type="download_binary">
+                <url_template architecture="x86_64" os="linux">http://hgdownload.cse.ucsc.edu/admin/exe/linux.x86_64/bedSort</url_template>
+              </action>
+              <action type="chmod">
+                <file mode="755">$INSTALL_DIR/bedSort</file>
               </action>
 	      <!-- bedGraphToBigWig -->
               <action type="download_binary">


### PR DESCRIPTION
PR to fix two issues:

1. On some sytems the `bedgraphToBigWig` step fails because the input bedgraph file is incorrectly sorted; this fix inserts a `bedSort` step beforehand to ensure that the input is sorted correctly.

2. Explicitly checks the exit status of the `MACS2` command and forces stop if this is non-zero (previously the tool will continue to run).