### PR TITLE
Turn off conda auto-init and auto-install when running planemo tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,5 @@ script:
 # Use the Galaxy virtualenv
   - ". travis/galaxy_venv/bin/activate"
 # Run tool tests
-  - "tools/$TOOL/run_planemo_tests.sh --galaxy_root travis/galaxy"
+  - "tools/$TOOL/run_planemo_tests.sh --galaxy_root travis/galaxy --no_conda_auto_install --no_conda_auto_init"
 


### PR DESCRIPTION
The update to using the `conda` dependency resolver appears to have broken the Travis-CI tests for a couple of tools (specifically `pal_finder` and `macs21`).

The immediate solution is to turn off the use of `conda` when running the tests for now. Longer term however the tool dependencies should be migrated to `conda`.