### PR TITLE
Update pal_finder tool to handle big logfiles

### DIFF
--- a/tools/pal_finder/README.rst
+++ b/tools/pal_finder/README.rst
@@ -60,6 +60,11 @@ History
 ========== ======================================================================
 Version    Changes
 ---------- ----------------------------------------------------------------------
+
+0.02.04.5  - Update to handle large output files which can sometimes be generated
+             by the ``pal_finder_v0.02.04.pl`` or ``pal_filter.py`` scripts (logs
+             of hundreds of Gb's have been observed in production): log files
+             longer than 500 lines are now truncated to avoid downstream problems. 
 0.02.04.4  - Update to the filter script (``pal_filter.py``) which removes some
              columns from the output assembly file.
 0.02.04.3  - Update to the Illumina filtering script from Graeme Fox (including

--- a/tools/pal_finder/pal_finder_wrapper.sh
+++ b/tools/pal_finder/pal_finder_wrapper.sh
@@ -313,8 +313,16 @@ set_config_value PRIMER_PAIR_MAX_DIFF_TM "$PRIMER_PAIR_MAX_DIFF_TM" config.txt
 #
 # Run pal_finder
 echo "### Running pal_finder ###"
-perl $PALFINDER_SCRIPT_DIR/pal_finder_v0.02.04.pl config.txt 2>&1 | tee pal_finder.log
-echo "### pal_finder finised ###"
+perl $PALFINDER_SCRIPT_DIR/pal_finder_v0.02.04.pl config.txt 1>pal_finder.log 2>&1
+echo "### pal_finder finished ###"
+#
+# Handlers the pal_finder log file
+echo "### Output from pal_finder ###"
+if [ $(wc -l pal_finder.log | cut -d" " -f1) -gt 500 ] ; then
+    echo WARNING output too long, truncated to last 500 lines:
+    echo ...
+fi
+tail -500 pal_finder.log
 #
 # Check that log ends with "Done!!" message
 if [ -z "$(tail -n 1 pal_finder.log | grep Done!!)" ] ; then
@@ -335,7 +343,13 @@ mv Output/PAL_summary.sorted.txt Output/PAL_summary.txt
 # Run the filtering & assembly script
 if [ ! -z "$FILTERED_MICROSATS" ] || [ ! -z "$OUTPUT_ASSEMBLY" ] ; then
     echo "### Running filtering & assembly script ###"
-    python $PALFINDER_FILTER -i $fastq_r1 -j $fastq_r2 -p Output/PAL_summary.txt $FILTER_OPTIONS 2>&1
+    python $PALFINDER_FILTER -i $fastq_r1 -j $fastq_r2 -p Output/PAL_summary.txt $FILTER_OPTIONS 1>pal_filter.log 2>&1
+    echo "### Output from pal_filter ###"
+    if [ $(wc -l pal_filter.log | cut -d" " -f1) -gt 500 ] ; then
+	echo WARNING output too long, truncated to last 500 lines:
+	echo ...
+    fi
+    tail -500 pal_filter.log
     if [ $? -ne 0 ] ; then
 	echo ERROR $PALFINDER_FILTER exited with non-zero status >&2
 	exit 1

--- a/tools/pal_finder/pal_finder_wrapper.sh
+++ b/tools/pal_finder/pal_finder_wrapper.sh
@@ -385,5 +385,7 @@ fi
 if [ ! -z "$OUTPUT_CONFIG_FILE" ] && [ -f config.txt ] ; then
     /bin/mv config.txt $OUTPUT_CONFIG_FILE
 fi
+#
+echo "### Pal_finder tool completed ###"
 ##
 #

--- a/tools/pal_finder/pal_finder_wrapper.sh
+++ b/tools/pal_finder/pal_finder_wrapper.sh
@@ -50,6 +50,9 @@
 echo "### $(basename $0) ###"
 echo $*
 #
+# Maximum size reporting log file contents
+MAX_LINES=500
+#
 # Initialise locations of scripts, data and executables
 #
 # Set these in the environment to overide at execution time
@@ -318,11 +321,11 @@ echo "### pal_finder finished ###"
 #
 # Handlers the pal_finder log file
 echo "### Output from pal_finder ###"
-if [ $(wc -l pal_finder.log | cut -d" " -f1) -gt 500 ] ; then
-    echo WARNING output too long, truncated to last 500 lines:
+if [ $(wc -l pal_finder.log | cut -d" " -f1) -gt $MAX_LINES ] ; then
+    echo WARNING output too long, truncated to last $MAX_LINES lines:
     echo ...
 fi
-tail -500 pal_finder.log
+tail -$MAX_LINES pal_finder.log
 #
 # Check that log ends with "Done!!" message
 if [ -z "$(tail -n 1 pal_finder.log | grep Done!!)" ] ; then
@@ -345,11 +348,11 @@ if [ ! -z "$FILTERED_MICROSATS" ] || [ ! -z "$OUTPUT_ASSEMBLY" ] ; then
     echo "### Running filtering & assembly script ###"
     python $PALFINDER_FILTER -i $fastq_r1 -j $fastq_r2 -p Output/PAL_summary.txt $FILTER_OPTIONS 1>pal_filter.log 2>&1
     echo "### Output from pal_filter ###"
-    if [ $(wc -l pal_filter.log | cut -d" " -f1) -gt 500 ] ; then
-	echo WARNING output too long, truncated to last 500 lines:
+    if [ $(wc -l pal_filter.log | cut -d" " -f1) -gt $MAX_LINES ] ; then
+	echo WARNING output too long, truncated to last $MAX_LINES lines:
 	echo ...
     fi
-    tail -500 pal_filter.log
+    tail -$MAX_LINES pal_filter.log
     if [ $? -ne 0 ] ; then
 	echo ERROR $PALFINDER_FILTER exited with non-zero status >&2
 	exit 1

--- a/tools/pal_finder/pal_finder_wrapper.xml
+++ b/tools/pal_finder/pal_finder_wrapper.xml
@@ -1,4 +1,4 @@
-<tool id="microsat_pal_finder" name="pal_finder" version="0.02.04.4">
+<tool id="microsat_pal_finder" name="pal_finder" version="0.02.04.5">
   <description>Find microsatellite repeat elements from sequencing reads and design PCR primers to amplify them</description>
   <requirements>
     <requirement type="package" version="5.16.3">perl</requirement>


### PR DESCRIPTION
PR which deals with very big log files that can be produced from both `pal_finder` and `pal_filter` in some cases (for example, when an error occurs in the `pal_finder` Perl script, or when `pandaseq` warns of a large number of poor quality assemblies).

The update captures the log files and limits the number of lines that are reported to 500. The limit is imposed regardless of whether the job was successful or not.