### PR TITLE
Added missing minAdapterLength and keepBothReads parameters

### DIFF
--- a/tools/trimmomatic/trimmomatic.xml
+++ b/tools/trimmomatic/trimmomatic.xml
@@ -33,7 +33,11 @@
   #end if
   ## ILLUMINACLIP option
   #if $illuminaclip.do_illuminaclip
-    ILLUMINACLIP:\$TRIMMOMATIC_ADAPTERS_PATH/$illuminaclip.adapter_fasta:$illuminaclip.seed_mismatches:$illuminaclip.palindrome_clip_threshold:$illuminaclip.simple_clip_threshold
+    #if $readtype.single_or_paired in ["pair_of_files","collection"]
+      ILLUMINACLIP:\$TRIMMOMATIC_ADAPTERS_PATH/$illuminaclip.adapter_fasta:$illuminaclip.seed_mismatches:$illuminaclip.palindrome_clip_threshold:$illuminaclip.simple_clip_threshold:$illuminaclip.min_adapter_len:$illuminaclip.keep_both_reads
+    #else
+      ILLUMINACLIP:\$TRIMMOMATIC_ADAPTERS_PATH/$illuminaclip.adapter_fasta:$illuminaclip.seed_mismatches:$illuminaclip.palindrome_clip_threshold:$illuminaclip.simple_clip_threshold
+    #end if
   #end if
   ## Other operations
   #for $op in $operations
@@ -115,6 +119,10 @@
         <param name="seed_mismatches" type="integer" label="Maximum mismatch count which will still allow a full match to be performed" value="2" />
         <param name="palindrome_clip_threshold" type="integer" label="How accurate the match between the two 'adapter ligated' reads must be for PE palindrome read alignment" value="30" />
         <param name="simple_clip_threshold" type="integer" label="How accurate the match between any adapter etc. sequence must be against a read" value="10" />
+        <param name="min_adapter_len" type="integer" label="Minimum length of adapter that needs to be detected (PE specific/palindrome mode)" value="2" />
+        <param name="keep_both_reads" type="boolean" label="Always keep both reads (PE specific/palindrome mode)?"
+           help="After read-though has been detected by palindrome mode, and the adapter sequence removed, the reverse read contains the same sequence information as the forward read, albeit in reverse complement. For this reason, the default behaviour is to entirely drop the reverse read. By specifying „true‟ for this parameter, the reverse read will also be retained, which may be useful e.g. if the downstream tools cannot handle a combination of paired and unpaired reads."
+           truevalue="true" falsevalue="false" checked="true" />
       </when>
       <when value="no" /> <!-- empty clause to satisfy planemo lint -->
     </conditional>


### PR DESCRIPTION
Added missing minAdapterLength and keepBothReads parameters for palindrome mode of ILLUMINACLIP step.
(forked from @cgirardot and rebased).