### PR TITLE
CEAS: fix check for unspecified genome build/dbkey (i.e. '?')

### DIFF
--- a/tools/ceas/ceas_wrapper.sh
+++ b/tools/ceas/ceas_wrapper.sh
@@ -32,18 +32,17 @@ while [ ! -z "$6" ] ; do
     elif [ "$6" == "--length" ] ; then
 	# Need a chrom sizes file
 	chrom_sizes=$7
-	if [ ! -f "$chrom_sizes" ] ; then
+	# Check the dbkey is set
+	dbkey=$(echo $(basename $chrom_sizes) | cut -d'.' -f1)
+	if [ $dbkey == '?' ] ; then
+	    # DBkey not set, this is fatal
+	    echo "ERROR genome build not set (name is '?')" >&2
+	    echo "Assign a genome build to your input dataset and rerun" >&2
+	    exit 1
+	elif [ ! -f "$chrom_sizes" ] ; then
 	    # If chrom sizes file doesn't already exist then attempt to
-	    # download the data from UCSC
+	    # download the data from UCSC using fetchChromSizes
 	    echo "WARNING no file $chrom_sizes"
-	    dbkey=$(echo $(basename $chrom_sizes) | cut -d'.' -f1)
-	    if [ $dbkey == '?' ] ; then
-		# DBkey not set, this is fatal
-		echo "ERROR genome build not set, cannot get sizes for '?'" >&2
-		echo "Assign a genome build to your input dataset and rerun" >&2
-		exit 1
-	    fi
-	    # Fetch the sizes using fetchChromSizes
 	    echo -n "Attempting to download chromosome sizes for $dbkey..."
 	    chrom_sizes=$(basename $chrom_sizes)
 	    fetchChromSizes $dbkey >$chrom_sizes 2>/dev/null

--- a/tools/ceas/ceas_wrapper.xml
+++ b/tools/ceas/ceas_wrapper.xml
@@ -96,6 +96,12 @@
       <output name="pdf_report" file="ceas_out3.pdf" />
       <output name="xls_output" file="ceas_out3.xls" />
     </test>
+    <test expect_failure="true" expect_exit_code="1">
+      <!-- Test expected failure with unspecified dbkey -->
+      <param name="bed_file" value="ceas_in.bed" ftype="bed" dbkey="?" />
+      <param name="wig_file" value="ceas_in.bigwig" ftype="bigwig" />
+      <param name="gdb_file" value="galGal3_test" />
+    </test>
   </tests>
   <help>
 **What it does**


### PR DESCRIPTION
PR which attempts to fix the check for an unspecified dbkey (i.e. when dbkey is set to '?'), and adds a new test case which checks that the tool fails in this case.