### PR TITLE
Travis CI: update test environment (samtools/planemo/Galaxy source)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - "bioinf-software-install/install_galaxy.sh --repo https://github.com/galaxyproject/galaxy/ --release release_17.09 travis"
 # Install planemo
   - "virtualenv planemo_venv"
-  - ". travis/planemo_venv/bin/activate"
+  - ". planemo_venv/bin/activate"
 # Update setuptools before installing planemo
 # See https://github.com/galaxyproject/planemo/issues/520
   - "pip install --upgrade pip setuptools"

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ install:
 
 script:
 # Use the Galaxy virtualenv
-  - ". travis/planemo_venv/bin/activate"
+  - ". planemo_venv/bin/activate"
 # Run tool tests
   - "tools/$TOOL/run_planemo_tests.sh --galaxy_root travis/galaxy $PLANEMO_OPTIONS"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,11 @@ before_install:
 install:
 # Get the installer scripts
   - "git clone https://github.com/pjbriggs/bioinf-software-install.git"
-# Install Samtools 0.1.18
-  - "wget http://sourceforge.net/projects/samtools/files/samtools/0.1.18/samtools-0.1.18.tar.bz2"
-  - "bioinf-software-install/install_samtools.sh samtools-0.1.18.tar.bz2 apps"
-  - "export PATH=$PATH:$PWD/apps/samtools/0.1.18/"
 # Bootstrap Galaxy instance for tests
   - "bioinf-software-install/install_galaxy.sh --repo https://github.com/galaxyproject/galaxy/ --release release_17.09 travis"
-  - ". travis/galaxy_venv/bin/activate"
+# Install planemo
+  - "virtualenv planemo_venv"
+  - ". travis/planemo_venv/bin/activate"
 # Update setuptools before installing planemo
 # See https://github.com/galaxyproject/planemo/issues/520
   - "pip install --upgrade pip setuptools"
@@ -39,7 +37,7 @@ install:
 
 script:
 # Use the Galaxy virtualenv
-  - ". travis/galaxy_venv/bin/activate"
+  - ". travis/planemo_venv/bin/activate"
 # Run tool tests
   - "tools/$TOOL/run_planemo_tests.sh --galaxy_root travis/galaxy $PLANEMO_OPTIONS"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 # Get the installer scripts
   - "git clone https://github.com/pjbriggs/bioinf-software-install.git"
 # Bootstrap Galaxy instance for tests
-  - "bioinf-software-install/install_galaxy.sh --repo https://github.com/galaxyproject/galaxy/ --release release_17.09 travis"
+  - "bioinf-software-install/install_galaxy.sh --repo https://github.com/galaxyproject/galaxy/ --release release_17.09 --bare travis"
 # Install planemo
   - "virtualenv planemo_venv"
   - ". planemo_venv/bin/activate"


### PR DESCRIPTION
PR which updates the test environment used by Travis CI to:

* No longer install `samtools`
* Use a dedicated virtualenv to install `planemo` into

These changes should reduce the amount of work being done to set up the test environment in future.