### PR TITLE
pal_finder: use a subset of reads

### DIFF
--- a/tools/pal_finder/fastq_subset.py
+++ b/tools/pal_finder/fastq_subset.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+import argparse
+import random
+from Bio.SeqIO.QualityIO import FastqGeneralIterator
+
+def count_reads(fastq):
+    """
+    """
+    n = 0
+    with open(fastq,'r') as fq:
+        while True:
+            buf = fq.read()
+            n += buf.count('\n')
+            if buf == "": break
+    return n/4
+
+def fastq_subset(fastq_in,fastq_out,indices):
+    """
+    """
+    with open(fastq_in,'r') as fq_in:
+        fq_out = open(fastq_out,'w')
+        i = 0
+        for title,seq,qual in FastqGeneralIterator(fq_in):
+            if i in indices:
+                fq_out.write("@%s\n%s\n+\n%s\n" % (title,
+                                                   seq,
+                                                   qual))
+            i += 1
+        fq_out.close()
+
+if __name__ == "__main__":
+
+    p = argparse.ArgumentParser()
+    p.add_argument("fastq_r1")
+    p.add_argument("fastq_r2")
+    p.add_argument("-n",
+                   dest="subset_size",
+                   default=None,
+                   help="subset size")
+    p.add_argument("-s",
+                   dest="seed",
+                   type=int,
+                   default=None,
+                   help="seed for random number generator")
+    args = p.parse_args()
+
+    print "Processing fastq pair:"
+    print "\t%s" % args.fastq_r1
+    print "\t%s" % args.fastq_r2
+
+    nreads = count_reads(args.fastq_r1)
+    print "Counted %d reads in %s" % (nreads,args.fastq_r1)
+
+    if args.subset_size is not None:
+        subset_size = float(args.subset_size)
+        if subset_size < 1.0:
+            subset_size = int(nreads*subset_size)
+        else:
+            subset_size = int(subset_size)
+        print "Extracting subset of reads: %s" % subset_size
+        if args.seed is not None:
+            print "Random number generator seed: %d" % args.seed
+            random.seed(args.seed)
+        subset = random.sample(xrange(nreads),subset_size)
+        fastq_subset(args.fastq_r1,"subset_r1.fq",subset)
+        fastq_subset(args.fastq_r2,"subset_r2.fq",subset)

--- a/tools/pal_finder/fastq_subset.py
+++ b/tools/pal_finder/fastq_subset.py
@@ -6,6 +6,7 @@ from Bio.SeqIO.QualityIO import FastqGeneralIterator
 
 def count_reads(fastq):
     """
+    Count number of reads in a Fastq file
     """
     n = 0
     with open(fastq,'r') as fq:
@@ -17,6 +18,12 @@ def count_reads(fastq):
 
 def fastq_subset(fastq_in,fastq_out,indices):
     """
+    Output a subset of reads from a Fastq file
+
+    The reads to output are specifed by a list
+    of integer indices; only reads at those
+    positions in the input file will be written
+    to the output.
     """
     with open(fastq_in,'r') as fq_in:
         fq_out = open(fastq_out,'w')

--- a/tools/pal_finder/pal_finder_macros.xml
+++ b/tools/pal_finder/pal_finder_macros.xml
@@ -21,6 +21,23 @@
       </assert_contents>
     </output>
   </xml>
+  <xml name="output_illumina_microsat_subset_summary">
+    <output name="output_microsat_summary">
+      <assert_contents>
+	<has_line line="allExtended:&#009;0" />
+	<has_line line="allSpan:&#009;0" />
+	<has_line line="broken:&#009;0" />
+	<has_line line="compound:&#009;2" />
+	<has_line line="readsWithMicrosat:&#009;7" />
+	<has_line line="totalBases:&#009;1160" />
+	<has_line line="totalReads:&#009;10&#009;(2 x 5)" />
+	<has_line line="Microsat Type&#009;monomer length&#009;total loci&#009;loci w/ primers&#009;reads with loci&#009;total bases&#009;extended&#009;extended w/ primers&#009;spanning&#009;spanning w/ primers" />
+	<has_line_matching expression="(AC|TG)\t2\t6\t3\t6\t104\t0?\t0?\t0?\t0?" />
+	<has_line_matching expression="(AT|CG)\t2\t3\t0\t3\t38\t0?\t0?\t0?\t0?" />
+	<has_line_matching expression="(AG|TC)\t2\t0\t0\t0\t0\t0?\t0?\t0?\t0?" />
+      </assert_contents>
+    </output>
+  </xml>
   <xml name="output_454_microsat_summary">
     <output name="output_microsat_summary">
       <assert_contents>

--- a/tools/pal_finder/pal_finder_wrapper.sh
+++ b/tools/pal_finder/pal_finder_wrapper.sh
@@ -31,6 +31,7 @@
 # -primers: run the 'primers' filter option
 # -occurrences: run the 'occurrences' filter option
 # -rankmotifs: run the 'rankmotifs' filter option
+# --subset N: use a subset of reads of size N
 #
 # pal_finder is available from http://sourceforge.net/projects/palfinder/
 #
@@ -113,6 +114,8 @@ OUTPUT_CONFIG_FILE=
 OUTPUT_ASSEMBLY=
 FILTERED_MICROSATS=
 FILTER_OPTIONS=
+SUBSET=
+RANDOM_SEED=568765
 #
 # Collect command line arguments
 if [ $# -lt 2 ] ; then
@@ -224,6 +227,10 @@ while [ ! -z "$1" ] ; do
 	    shift
 	    OUTPUT_ASSEMBLY=$1
 	    ;;
+	--subset)
+	    shift
+	    SUBSET=$1
+	    ;;
 	*)
 	    echo Unknown option: $1 >&2
 	    exit 1
@@ -258,6 +265,14 @@ fi
 ln -s $PRIMER_MISPRIMING_LIBRARY
 PRIMER_MISPRIMING_LIBRARY=$(basename $PRIMER_MISPRIMING_LIBRARY)
 mkdir Output
+#
+# Use a subset of reads
+if [ ! -z "$SUBSET" ] ; then
+    echo "### Extracting subset of reads ###"
+    $(dirname $0)/fastq_subset.py -n $SUBSET -s $RANDOM_SEED $fastq_r1 $fastq_r2
+    fastq_r1="subset_r1.fq"
+    fastq_r2="subset_r2.fq"
+fi
 #
 # Copy in the default config.txt file
 echo "### Creating config.txt file for pal_finder run ###"

--- a/tools/pal_finder/pal_finder_wrapper.xml
+++ b/tools/pal_finder/pal_finder_wrapper.xml
@@ -251,6 +251,17 @@
       <output name="output_pal_summary" compare="re_match" file="illuminaPE_microsats.out.re_match" />
       <output name="output_filtered_microsats" compare="re_match" file="illuminaPE_filtered_microsats_rankmotifs.out.re_match" />
     </test>
+    <!-- Test with Illumina input using subset of reads -->
+    <test>
+      <param name="platform_type" value="illumina" />
+      <param name="filters" value="" />
+      <param name="assembly" value="false" />
+      <param name="subset" value="0.5" />
+      <param name="input_fastq_r1" value="illuminaPE_r1.fq" ftype="fastqsanger" />
+      <param name="input_fastq_r2" value="illuminaPE_r2.fq" ftype="fastqsanger" />
+      <expand macro="output_illumina_microsat_subset_summary" />
+      <output name="output_pal_summary" compare="re_match" file="illuminaPE_microsats_subset.out.re_match" />
+    </test>
     <!-- Test with Illumina input filter that doesn't find any
 	 microsatellites -->
     <test expect_failure="true">
@@ -263,7 +274,6 @@
       <assert_stderr>
 	<has_text text="pal_finder failed to locate any microsatellites" />
       </assert_stderr>
-    </test>
     <!-- Test with 454 input -->
     <test>
       <param name="platform_type" value="454" />

--- a/tools/pal_finder/pal_finder_wrapper.xml
+++ b/tools/pal_finder/pal_finder_wrapper.xml
@@ -61,6 +61,9 @@
     #if str( $platform.assembly ) == '-assembly'
       $platform.assembly "$output_assembly"
     #end if
+    #if str( $platform.subset ) != ""
+      --subset "$platform.subset"
+    #end if
   #end if
   ]]></command>
   <inputs>
@@ -88,6 +91,7 @@
 		   label="Select FASTQ dataset collection with R1/R2 pair" />
 	  </when>
 	</conditional>
+	<param name="subset" type="text" value="" label="Use a random subset of reads for microsatellite detection" help="Either an integer number of reads or a decimal fraction (e.g. 0.5); leave blank to use all reads" />
 	<param name="filters" type="select" display="checkboxes"
 	       multiple="True" label="Filters to apply to the pal_finder results"
 	       help="Apply none, one or more filters to refine results">

--- a/tools/pal_finder/pal_finder_wrapper.xml
+++ b/tools/pal_finder/pal_finder_wrapper.xml
@@ -274,6 +274,7 @@
       <assert_stderr>
 	<has_text text="pal_finder failed to locate any microsatellites" />
       </assert_stderr>
+    </test>
     <!-- Test with 454 input -->
     <test>
       <param name="platform_type" value="454" />

--- a/tools/pal_finder/pal_finder_wrapper.xml
+++ b/tools/pal_finder/pal_finder_wrapper.xml
@@ -61,8 +61,9 @@
     #if str( $platform.assembly ) == '-assembly'
       $platform.assembly "$output_assembly"
     #end if
-    #if str( $platform.subset ) != ""
-      --subset "$platform.subset"
+    #set $use_all_reads = $platform.subset_conditional.use_all_reads
+    #if str( $use_all_reads ) != "yes"
+      --subset "$platform.subset_conditional.subset"
     #end if
   #end if
   ]]></command>
@@ -91,7 +92,13 @@
 		   label="Select FASTQ dataset collection with R1/R2 pair" />
 	  </when>
 	</conditional>
-	<param name="subset" type="text" value="" label="Use a random subset of reads for microsatellite detection" help="Either an integer number of reads or a decimal fraction (e.g. 0.5); leave blank to use all reads" />
+	<conditional name="subset_conditional">
+	  <param name="use_all_reads" type="boolean" label="Use all reads for microsatellite detection?" checked="True" truevalue="yes" falsevalue="no" />
+	  <when value="no">
+	    <param name="subset" type="text" value="0.5" label="Number or fraction of reads to use" help="Either an integer number of reads or a decimal fraction (e.g. 0.5 to select 50% of reads)" />
+	  </when>
+	  <when value="yes" />
+	</conditional>
 	<param name="filters" type="select" display="checkboxes"
 	       multiple="True" label="Filters to apply to the pal_finder results"
 	       help="Apply none, one or more filters to refine results">
@@ -256,6 +263,7 @@
       <param name="platform_type" value="illumina" />
       <param name="filters" value="" />
       <param name="assembly" value="false" />
+      <param name="use_all_reads" value="no" />
       <param name="subset" value="0.5" />
       <param name="input_fastq_r1" value="illuminaPE_r1.fq" ftype="fastqsanger" />
       <param name="input_fastq_r2" value="illuminaPE_r2.fq" ftype="fastqsanger" />

--- a/tools/pal_finder/test-data/illuminaPE_microsats_subset.out.re_match
+++ b/tools/pal_finder/test-data/illuminaPE_microsats_subset.out.re_match
@@ -1,6 +1,6 @@
 readPairID\	Motifs\(bases\)\	Bases\ in\ all\ Motifs\	Possible\ Extended\	Possible\ Spanning\	Primers\ found\ \(1\=y\,0\=n\)\	F\ Primer\ Name\	Forward\ Primer\	R\ Primer\ Name\	Reverse\ Primer\	Amplicon\ Motifs\	Number\ motif\ bases\ in\ amplicon\	Primers\ on\ sep\ reads\	Extend\ with\ primers\	Spand\ with\ primers\	Occurances\ of\ Forward\ Primer\ in\ Reads\	Occurances\ of\ Reverse\ Primer\ in\ Reads\	Occurances\ of\ Amplifiable\ Primer\ Pair\ in\ Reads\	Occurances\ of\ Amplifiable\ Primer\ Pair\ in\ PALs
-ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:17449\:1584\	AC\(36\)\ \	36\	\	\	0\	\	\	\	\	\	\	\	\	\	\	\	\	
-ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:5626\:1554\	AT\(14\)\ AC\(16\)\ AC\(16\)\ AT\(12\)\ \	58\	\	\	0\	\	\	\	\	\	\	\	\	\	\	\	\	
+ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:17449\:1584\	(AC|TG)\(36\)\ \	36\	\	\	0\	\	\	\	\	\	\	\	\	\	\	\	\	
+ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:5626\:1554\	AT\(14\)\ (AC|TG)\(16\)\ (AC|TG)\(16\)\ AT\(12\)\ \	58\	\	\	0\	\	\	\	\	\	\	\	\	\	\	\	\	
 ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:5879\:1238\	AT\(12\)\ \	12\	\	\	0\	\	\	\	\	\	\	\	\	\	\	\	\	
-ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:8157\:1636\	AC\(12\)\ \	12\	\	\	1\	test\_.*\	AAGTACAGTGGGGAGGCTGG\	test\_.*\	TTTTCTACACAGCTCAAGTAGCCC\	AC\(12\)\ \	12\	1\	\	\	1\	1\	1\	1
-ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:8899\:1514\	AC\(12\)\ AC\(12\)\ \	24\	\	\	1\	test\_.*\	TCTTTATCTAAACACATCCTGAAATACC\	test\_.*\	AAACGCAATTATTTTGAGATGTCC\	AC\(12\)\ AC\(12\)\ \	24\	1\	\	\	1\	2\	1\	1
+ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:8157\:1636\	(AC|TG)\(12\)\ \	12\	\	\	1\	test\_.*\	AAGTACAGTGGGGAGGCTGG\	test\_.*\	TTTTCTACACAGCTCAAGTAGCCC\	(AC|TG)\(12\)\ \	12\	1\	\	\	1\	1\	1\	1
+ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:8899\:1514\	(AC|TG)\(12\)\ (AC|TG)\(12\)\ \	24\	\	\	1\	test\_.*\	TCTTTATCTAAACACATCCTGAAATACC\	test\_.*\	AAACGCAATTATTTTGAGATGTCC\	(AC|TG)\(12\)\ (AC|TG)\(12\)\ \	24\	1\	\	\	1\	2\	1\	1

--- a/tools/pal_finder/test-data/illuminaPE_microsats_subset.out.re_match
+++ b/tools/pal_finder/test-data/illuminaPE_microsats_subset.out.re_match
@@ -1,0 +1,6 @@
+readPairID\	Motifs\(bases\)\	Bases\ in\ all\ Motifs\	Possible\ Extended\	Possible\ Spanning\	Primers\ found\ \(1\=y\,0\=n\)\	F\ Primer\ Name\	Forward\ Primer\	R\ Primer\ Name\	Reverse\ Primer\	Amplicon\ Motifs\	Number\ motif\ bases\ in\ amplicon\	Primers\ on\ sep\ reads\	Extend\ with\ primers\	Spand\ with\ primers\	Occurances\ of\ Forward\ Primer\ in\ Reads\	Occurances\ of\ Reverse\ Primer\ in\ Reads\	Occurances\ of\ Amplifiable\ Primer\ Pair\ in\ Reads\	Occurances\ of\ Amplifiable\ Primer\ Pair\ in\ PALs
+ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:17449\:1584\	AC\(36\)\ \	36\	\	\	0\	\	\	\	\	\	\	\	\	\	\	\	\	
+ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:5626\:1554\	AT\(14\)\ AC\(16\)\ AC\(16\)\ AT\(12\)\ \	58\	\	\	0\	\	\	\	\	\	\	\	\	\	\	\	\	
+ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:5879\:1238\	AT\(12\)\ \	12\	\	\	0\	\	\	\	\	\	\	\	\	\	\	\	\	
+ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:8157\:1636\	AC\(12\)\ \	12\	\	\	1\	test\_.*\	AAGTACAGTGGGGAGGCTGG\	test\_.*\	TTTTCTACACAGCTCAAGTAGCCC\	AC\(12\)\ \	12\	1\	\	\	1\	1\	1\	1
+ILLUMINA\-545855\:49\:FC61RLR\:2\:1\:8899\:1514\	AC\(12\)\ AC\(12\)\ \	24\	\	\	1\	test\_.*\	TCTTTATCTAAACACATCCTGAAATACC\	test\_.*\	AAACGCAATTATTTTGAGATGTCC\	AC\(12\)\ AC\(12\)\ \	24\	1\	\	\	1\	2\	1\	1


### PR DESCRIPTION
PR aiming to address issue #51 and enable the tool to use a subset of read pairs from the input Fastq files.