### PR TITLE
motif_tools: add missing Perl scripts to packager script

### DIFF
--- a/tools/motif_tools/package_motif_tools.sh
+++ b/tools/motif_tools/package_motif_tools.sh
@@ -12,10 +12,14 @@ fi
 tar cvzf $TGZ \
     README.rst \
     CountUniqueIDs.xml \
+    CountUniqueIDs.pl \
     Scan_IUPAC_output_each_match.xml \
+    Scan_IUPAC_output_each_match.pl \
     Scan_IUPAC_output_matches_per_seq.xml \
+    Scan_IUPAC_output_matches_per_seq.pl \
     TFBScluster_candidates_2TFBS.xml \
     TFBScluster_candidates_3TFBS.xml \
+    TFBScluster_candidates.pl \
     motif_tools_macros.xml \
     test-data
 if [ -f $TGZ ] ; then


### PR DESCRIPTION
The `motif_tools` tools were broken on the toolshed because the packager script didn't include the Perl scripts; this PR should fix this problem.