### PR TITLE
rnachipintegrator: update to latest RnaChipIntegrator version 1.1.0.

### DIFF
--- a/tools/rnachipintegrator/README.rst
+++ b/tools/rnachipintegrator/README.rst
@@ -90,6 +90,8 @@ History
 ========== ======================================================================
 Version    Changes
 ---------- ----------------------------------------------------------------------
+1.1.0.0    - Update to ``RnaChipIntegrator`` version 1.1.0 (fixes bug with
+             missing peaks in gene-centric analyses when using both edges)
 1.0.3.1    - Fetch dependencies from conda if not otherwise satisfied
 1.0.3.0    - Update to ``RnaChipIntegrator`` version 1.0.3
 1.0.2.0    - Update to ``RnaChipIntegrator`` version 1.0.2 (fixes bug with

--- a/tools/rnachipintegrator/rnachipintegrator_macros.xml
+++ b/tools/rnachipintegrator/rnachipintegrator_macros.xml
@@ -1,9 +1,9 @@
 <macros>
-  <token name="@VERSION@">1.0.3.1</token>
+  <token name="@VERSION@">1.1.0.0</token>
   <xml name="requirements">
     <requirements>
       <requirement type="package" version="2.7">python</requirement>
-      <requirement type="package" version="1.0.3">rnachipintegrator</requirement>
+      <requirement type="package" version="1.1.0">rnachipintegrator</requirement>
     </requirements>
   </xml>
   <xml name="version_command">
@@ -61,7 +61,7 @@
   journal = {GitHub repository},
   year = {2016},
   howpublished = {\url{https://github.com/fls-bioinformatics-core/RnaChipIntegrator}},
-  version = {1.0.0}
+  version = {1.1.0}
 }</citation>
     </citations>
   </xml>


### PR DESCRIPTION
`RnaChipIntegrator` has been updated to version 1.1.0; this PR updates the Galaxy tools to use this version. NB although there are new options in `RnaChipIntegrator`, this PR doesn't add any new features to the tool.