### PR TITLE
motif_tools: bump perl-bioperl dependency from 1.6.924 to 1.7.2.

### DIFF
--- a/tools/motif_tools/motif_tools_macros.xml
+++ b/tools/motif_tools/motif_tools_macros.xml
@@ -2,8 +2,7 @@
   <token name="@VERSION@">1.0.1</token>
   <xml name="requirements">
     <requirements>
-      <requirement type="package" version="1.6.924">perl-bioperl</requirement
->
+      <requirement type="package" version="1.7.2">perl-bioperl</requirement>
     </requirements>
   </xml>
 </macros>


### PR DESCRIPTION
PR to address issue #70 by updating the `perl-bioperl` conda dependency of the `motif_tools` Galaxy tool package to version 1.7.2 (which seems to work okay).