### PR TITLE
readlink -f instead of readlink -e more portable

### DIFF
--- a/tools/trimmomatic/trimmomatic_macros.xml
+++ b/tools/trimmomatic/trimmomatic_macros.xml
@@ -3,6 +3,6 @@
        Set the path for the trimmomatic JAR and data files
        Based on https://github.com/galaxyproject/tools-iuc/blob/master/tool_collections/snpsift/snpSift_macros.xml#L13
   -->
-  <token name="@CONDA_TRIMMOMATIC_JAR_PATH@">if [ -z "\$TRIMMOMATIC_JAR_PATH" ]; then export TRIMMOMATIC_JAR_PATH=\$(dirname \$(readlink -e \$(which trimmomatic))); fi</token>
-  <token name="@CONDA_TRIMMOMATIC_ADAPTERS_PATH@">if [ -z "\$TRIMMOMATIC_ADAPTERS_PATH" ]; then export TRIMMOMATIC_ADAPTERS_PATH=\$(dirname \$(readlink -e \$(which trimmomatic)))/adapters; fi</token>
+  <token name="@CONDA_TRIMMOMATIC_JAR_PATH@">if [ -z "\$TRIMMOMATIC_JAR_PATH" ]; then export TRIMMOMATIC_JAR_PATH=\$(dirname \$(readlink -f \$(which trimmomatic))); fi</token>
+  <token name="@CONDA_TRIMMOMATIC_ADAPTERS_PATH@">if [ -z "\$TRIMMOMATIC_ADAPTERS_PATH" ]; then export TRIMMOMATIC_ADAPTERS_PATH=\$(dirname \$(readlink -f \$(which trimmomatic)))/adapters; fi</token>
 </macros>


### PR DESCRIPTION
I ran into an error using the trimmomatic docker image that is generated from the trimmomatic conda package.
These images are minimal busbox containers, and the readlink command there doesn't know about -e. -f is perfectly fine in this scenario:
```
Print value of a symbolic link or canonical file name

  -f, --canonicalize            canonicalize by following every symlink in
                                every component of the given name recursively;
                                all but the last component must exist
  -e, --canonicalize-existing   canonicalize by following every symlink in
                                every component of the given name recursively,
                                all components must exist
```