### PR TITLE
Trimmomatic: use 'readlink' from coreutils package for cross-platform support

### DIFF
--- a/tools/trimmomatic/README.rst
+++ b/tools/trimmomatic/README.rst
@@ -46,9 +46,9 @@ by adding the line:
 
     <tool file="trimmomatic/trimmomatic.xml" />
 
-You will also need to install trimmomatic 0.36:
+You will also need to install trimmomatic 0.38:
 
-- http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.36.zip
+- http://www.usadellab.org/cms/uploads/supplementary/Trimmomatic/Trimmomatic-0.38.zip
 
 The tool wrapper uses the following environment variables in order to find the
 appropriate files:

--- a/tools/trimmomatic/README.rst
+++ b/tools/trimmomatic/README.rst
@@ -71,6 +71,8 @@ History
 ========== ======================================================================
 Version    Changes
 ---------- ----------------------------------------------------------------------
+0.38.1     - Bug fix: add dependency on ``coreutils`` so that ``readlink -e`` is
+             supported across both Linux and MacOS platforms.
 0.38.0     - Update to Trimmomatic 0.38.
 0.36.6     - Added trimlog and log outputs; add support for ``fastqillumina``
              and ``fastqsolexa`` input types
@@ -117,6 +119,8 @@ Peter van Heusden (@pvanheus) and Marius van den Beek (@mvdbeek) contributed
 support for gz compressed FastQ files. Charles Girardot (@cgirardot) and
 Jelle Scholtalbers (@scholtalbers) contributed additional options to ILLUMINACLIP.
 Matthias Bernt (@bernt-matthias) added log and trimlog output.
+Nicola Soranzo (@nsoranzo) suggested using coreutils to enable cross-platform
+support across Linux and MacOS.
 
 Developers
 ==========

--- a/tools/trimmomatic/trimmomatic.xml
+++ b/tools/trimmomatic/trimmomatic.xml
@@ -5,6 +5,12 @@
   </macros>
   <requirements>
     <requirement type="package" version="0.38">trimmomatic</requirement>
+    <!--
+	Coreutils required for 'readlink -e' work across platforms
+	See similar fix for snpSift
+	https://github.com/galaxyproject/tools-iuc/commit/b5e2080a7afdea9fa476895693b6115824c6fbb9
+    -->
+    <requirement type="package" version="8.25">coreutils</requirement>
   </requirements>
   <command detect_errors="aggressive"><![CDATA[
   @CONDA_TRIMMOMATIC_JAR_PATH@ &&

--- a/tools/trimmomatic/trimmomatic.xml
+++ b/tools/trimmomatic/trimmomatic.xml
@@ -1,4 +1,4 @@
-<tool id="trimmomatic" name="Trimmomatic" version="0.38.0">
+<tool id="trimmomatic" name="Trimmomatic" version="0.38.1">
   <description>flexible read trimming tool for Illumina NGS data</description>
   <macros>
     <import>trimmomatic_macros.xml</import>

--- a/tools/trimmomatic/trimmomatic_macros.xml
+++ b/tools/trimmomatic/trimmomatic_macros.xml
@@ -3,6 +3,6 @@
        Set the path for the trimmomatic JAR and data files
        Based on https://github.com/galaxyproject/tools-iuc/blob/master/tool_collections/snpsift/snpSift_macros.xml#L13
   -->
-  <token name="@CONDA_TRIMMOMATIC_JAR_PATH@">if [ -z "\$TRIMMOMATIC_JAR_PATH" ]; then export TRIMMOMATIC_JAR_PATH=\$(dirname \$(readlink -f \$(which trimmomatic))); fi</token>
-  <token name="@CONDA_TRIMMOMATIC_ADAPTERS_PATH@">if [ -z "\$TRIMMOMATIC_ADAPTERS_PATH" ]; then export TRIMMOMATIC_ADAPTERS_PATH=\$(dirname \$(readlink -f \$(which trimmomatic)))/adapters; fi</token>
+  <token name="@CONDA_TRIMMOMATIC_JAR_PATH@">if [ -z "\$TRIMMOMATIC_JAR_PATH" ]; then export TRIMMOMATIC_JAR_PATH=\$(dirname \$(readlink -e \$(which trimmomatic))); fi</token>
+  <token name="@CONDA_TRIMMOMATIC_ADAPTERS_PATH@">if [ -z "\$TRIMMOMATIC_ADAPTERS_PATH" ]; then export TRIMMOMATIC_ADAPTERS_PATH=\$(dirname \$(readlink -e \$(which trimmomatic)))/adapters; fi</token>
 </macros>


### PR DESCRIPTION
PR which implements the suggestion appended to PR #74, to use the version of `readlink` from the `coreutils` package.

The previous PR switched from `-e` to `-f`, but this reportedly broke the tool for MacOS. This latest PR restores `-e` but using `coreutils` should ensure that this time it is supported across all platforms. 