### PR TITLE
Update Travis CI tests to Python 3 & Galaxy 19.09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ env:
 before_install:
 # Update the list of available packages
   - sudo apt-get -qq update
-# Java needed for Trimmomatic
-  - "sudo apt-get install java-common"
 # Dependencies needed for Galaxy installer
   - sudo apt-get install pwgen
   - sudo apt-get install r-base

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Config file for Travis CI
 language: python
 python:
-  - "2.7"
+  - "3.6"
 # Attempt to split the tests into separate
 # environments
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,6 @@ install:
 # Install planemo
   - "virtualenv planemo_venv"
   - ". planemo_venv/bin/activate"
-# Update setuptools before installing planemo
-# See https://github.com/galaxyproject/planemo/issues/520
-  - "pip install --upgrade pip setuptools"
 # Install planemo to do the testing
   - "pip install planemo"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 # Get the installer scripts
   - "git clone https://github.com/pjbriggs/bioinf-software-install.git"
 # Bootstrap Galaxy instance for tests
-  - "bioinf-software-install/install_galaxy.sh --repo https://github.com/galaxyproject/galaxy/ --release release_18.05 --bare travis"
+  - "bioinf-software-install/install_galaxy.sh --repo https://github.com/galaxyproject/galaxy/ --release release_19.09 --bare travis"
 # Install planemo
   - "virtualenv planemo_venv"
   - ". planemo_venv/bin/activate"


### PR DESCRIPTION
PR which fixes broken Travis CI testing by updating to Python 3.6 (also addressing issue #76).

The update also requires that the target Galaxy version that the tool tests are run against is bumped to 19.09 (this is the first version that supported Python 3).

In addition some other updates have been made, specifically:

* Drop installation of Java (this should be taken care of by the conda dependency resolver now)
* Drop update of `setuptools` in the virtualenv used to install `planemo` (no longer required)