### PR TITLE
pal_finder: improve reporting of specific errors associated with SRR Fastq read headers

### DIFF
--- a/tools/pal_finder/pal_finder_wrapper.sh
+++ b/tools/pal_finder/pal_finder_wrapper.sh
@@ -351,7 +351,13 @@ if [ ! -z "$(tail -n 1 pal_finder.log | grep 'No microsatellites found in any re
     exit 1
 elif [ -z "$(tail -n 1 pal_finder.log | grep Done!!)" ] ; then
     # Log doesn't end with "Done!!" (indicates failure)
-    fatal ERROR pal_finder failed to complete successfully
+    errmsg="ERROR pal_finder failed to complete successfully"
+    if [ -z "$(grep 'Non-valid paired end read' pal_finder.log)" ] ; then
+	errmsg="${errmsg}: unable to pair reads?"
+    elif [ -z "$(grep 'Sequence Tag .* not in correct format' pal_finder.log)" ] ; then
+	errmsg="${errmsg}: unable to extract sequence tags from Fastqs?"
+    fi
+    fatal $errmsg
 fi
 echo "### pal_finder finished ###"
 #


### PR DESCRIPTION
PR which updates the wrapper script within the `pal_finder` tool, to detect and report specific errors which are associated with SRR Fastq read headers (though they could potentially affect other non-Illumina-style Fastq files).

SRR read headers take the form:

    @SRR13076875.1 1/1

and so far seem to result in failures of the Pal_finder script to complete, leaving messages in the Pal_finder log of the form:

    Sequence Tag  not in correct format

and

    Non-valid paired end read

The PR updates the final error message to include more information in either of these cases.