### PR TITLE
macs21: update versions of UCSC tools in requirements

### DIFF
--- a/tools/macs21/README.rst
+++ b/tools/macs21/README.rst
@@ -56,21 +56,22 @@ This version has been substantially modified both to adapt it to MACS 2.1, and
 to re-implement the internal workings of the tool to conform with current
 practices in invoking commands from Galaxy, and to add new functionality.
 
-========== ======================================================================
-Version    Changes
----------- ----------------------------------------------------------------------
-2.1.2.0    - Update to use MACS 2.1.2
-2.1.1.0    - Update to use MACS 2.1.1 and use conda to resolve dependencies
-2.1.0-6    - Add bedSort step into bigWig file generation; terminate with error
-             when MACS finishes with non-zero exit code.
-2.1.0-5    - User must explicitly specify the format for the inputs (to allow
-             for paired-end data)
-2.1.0-4    - Remove 'bdgcmp' functionality.
-2.1.0-3    - Add tool tests
-2.1.0-2    - Add option to create bigWig file from bedGraphs; fix bug with -B
-             option; make --mfold defaults consistent.
-2.1.0-1    - Initial version
-========== ======================================================================
+============= =================================================================
+Version       Changes
+------------- -----------------------------------------------------------------
+2.1.2-galaxy1 - Update UCSC tool dependencies to version 357
+2.1.2.0       - Update to use MACS 2.1.2
+2.1.1.0       - Update to use MACS 2.1.1 and use conda to resolve dependencies
+2.1.0-6       - Add bedSort step into bigWig file generation; terminate with
+                error when MACS finishes with non-zero exit code.
+2.1.0-5       - User must explicitly specify the format for the inputs (to
+                allow for paired-end data)
+2.1.0-4       - Remove 'bdgcmp' functionality.
+2.1.0-3       - Add tool tests
+2.1.0-2       - Add option to create bigWig file from bedGraphs; fix bug with
+                ``-B`` option; make ``--mfold`` defaults consistent.
+2.1.0-1       - Initial version
+============= =================================================================
 
 
 Developers

--- a/tools/macs21/macs21_wrapper.xml
+++ b/tools/macs21/macs21_wrapper.xml
@@ -1,13 +1,13 @@
-<tool id="macs2_1_peakcalling" name="MACS2.1.2" version="2.1.2.0">
+<tool id="macs2_1_peakcalling" name="MACS2.1.2" version="2.1.2-galaxy1">
   <description>Model-based Analysis of ChIP-Seq: peak calling</description>
   <requirements>
     <requirement type="package" version="2.7">python</requirement>
     <requirement type="package" version="2.1.2">macs2</requirement>
     <requirement type="package" version="3.5">R</requirement>
-    <requirement type="package" version="357">ucsc-fetchchromsizes</requirement>
-    <requirement type="package" version="357">ucsc-bedclip</requirement>
-    <requirement type="package" version="357">ucsc-bedsort</requirement>
-    <requirement type="package" version="357">ucsc-bedgraphtobigwig</requirement>
+    <requirement type="package" version="377">ucsc-fetchchromsizes</requirement>
+    <requirement type="package" version="377">ucsc-bedclip</requirement>
+    <requirement type="package" version="377">ucsc-bedsort</requirement>
+    <requirement type="package" version="377">ucsc-bedgraphtobigwig</requirement>
   </requirements>
   <version_command>macs2 --version</version_command>
   <command><![CDATA[


### PR DESCRIPTION
Updates the `macs21` tool to specify more recent versions (377) of the UCSC tools (`fetchChromSizes`, `bedSort`, `bedGraphToBigWig` and `bedClip`) as the previous versions (357) were failing in the tool tests.

Also updates the tool version to `2.1.2-galaxy1`.